### PR TITLE
Fix for machine object failing json.unmarshal when doing a terraform import

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -31,7 +31,7 @@ type Machine struct {
 	VolumeGroups                 []VolumeGroup       `json:"volume_groups,omitempty"`
 	InterfaceSet                 []NetworkInterface  `json:"interface_set,omitempty"`
 	BCaches                      []string            `json:"bcaches,omitempty"`
-	RAIDs                        []string            `json:"raids,omitempty"`
+	RAIDs                        []interface{}       `json:"raids,omitempty"`
 	SpecialFilesystems           []string            `json:"special_filesystems,omitempty"`
 	ServiceSet                   []MachineServiceSet `json:"service_set,omitempty"`
 	PhysicalBlockDeviceSet       []BlockDevice       `json:"physicalblockdevice_set,omitempty"`


### PR DESCRIPTION
When trying to import a machine into terraform state via `terraform import`, the command fails due to the incorrect data type in the Machine struct.

```
 Error: json: cannot unmarshal object into Go struct field Machine.raids of type string
```

This patch uses `[]interface{}` instead of `[]string` for `RAIDs`, which allows for successful unmarshal, hence allowing `terraform import` to run successfully.