### PR TITLE
Add option to enable hardware sync on deploy

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -83,6 +83,7 @@ type Machine struct {
 	DisableIPv4                  bool                `json:"disable_ipv4,omitempty"`
 	Netboot                      bool                `json:"netboot,omitempty"`
 	Locked                       bool                `json:"locked,omitempty"`
+	EnableHwSync                 bool                `json:"enable_hw_sync,omitempty"`
 }
 
 // MachineServiceSet represents a Machine's "service_set".
@@ -152,6 +153,7 @@ type MachineAllocateParams struct {
 	BridgeSTP        bool     `url:"bridge_stp,omitempty"`
 	DryRun           bool     `url:"dry_run,omitempty"`
 	Verbose          bool     `url:"verbose,omitempty"`
+	EnableHwSync     bool     `url:"enable_hw_sync,omitempty"`
 }
 
 // MachineDeployParams enumerates the parameters for the deploy operation
@@ -167,4 +169,5 @@ type MachineDeployParams struct {
 	InstallRackD   bool   `url:"install_rackd,omitempty"`
 	InstallKVM     bool   `url:"install_kvm,omitempty"`
 	RegisterVMHost bool   `url:"register_vmhost,omitempty"`
+	EnableHwSync   bool   `url:"enable_hw_sync,omitempty"`
 }


### PR DESCRIPTION
That is required to add this fubctionality in terraform-provider-maas