### PR TITLE
feat: expose hardware sync info

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -1,7 +1,11 @@
 package entity
 
 import (
+	"encoding/json"
+	"errors"
 	"net"
+	"strconv"
+	"time"
 
 	"github.com/maas/gomaasclient/entity/node"
 )
@@ -54,6 +58,10 @@ type Machine struct {
 	PowerType                    string              `json:"power_type,omitempty"`
 	OwnerData                    interface{}         `json:"owner_data,omitempty"`
 	Hostname                     string              `json:"hostname,omitempty"`
+	EnableHwSync                 bool                `json:"enable_hw_sync,omitempty"`
+	HwLastSync                   MAASTime            `json:"last_sync,omitempty"`
+	HwSyncInterval               int                 `json:"sync_interval,omitempty"`
+	HwNextSync                   MAASTime            `json:"next_sync,omitempty"`
 	Description                  string              `json:"description,omitempty"`
 	StatusAction                 string              `json:"status_action,omitempty"`
 	StatusMessage                string              `json:"status_message,omitempty"`
@@ -83,6 +91,53 @@ type Machine struct {
 	DisableIPv4                  bool                `json:"disable_ipv4,omitempty"`
 	Netboot                      bool                `json:"netboot,omitempty"`
 	Locked                       bool                `json:"locked,omitempty"`
+}
+
+func (m *Machine) UnmarshalJSON(data []byte) error {
+	type machine Machine
+
+	if err := json.Unmarshal(data, (*machine)(m)); err != nil {
+		return err
+	}
+
+	// NOTE: deduce field value for backward compatibility
+	// `enable_hw_sync` field is exposed via API in MAAS 3.4+
+	// but hardware sync feature was added in 3.2
+	if !m.EnableHwSync {
+		t := MAASTime{}
+		if m.HwSyncInterval != 0 && (m.HwNextSync != t || m.HwLastSync != t) {
+			m.EnableHwSync = true
+		}
+	}
+
+	return nil
+}
+
+// MAASTime is a custom time format returned by MAAS API
+// which is not RFC3339
+type MAASTime struct {
+	time.Time
+}
+
+func (t *MAASTime) UnmarshalJSON(data []byte) error {
+	str, err := strconv.Unquote(string(data))
+	if errors.Is(err, strconv.ErrSyntax) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	temp, err := time.Parse("2006-01-02T15:04:05.999", str)
+	if err != nil {
+		return err
+	}
+	*t = MAASTime{temp}
+	return nil
+}
+
+// String returns MAASTime in RFC3339Nano format
+func (t *MAASTime) String() string {
+	return t.Format(time.RFC3339Nano)
 }
 
 // MachineServiceSet represents a Machine's "service_set".

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -115,9 +115,7 @@ func (m *Machine) UnmarshalJSON(data []byte) error {
 
 // MAASTime is a custom time format returned by MAAS API
 // which is not RFC3339
-type MAASTime struct {
-	time.Time
-}
+type MAASTime time.Time
 
 func (t *MAASTime) UnmarshalJSON(data []byte) error {
 	str, err := strconv.Unquote(string(data))
@@ -131,13 +129,14 @@ func (t *MAASTime) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	*t = MAASTime{temp}
+	*t = MAASTime(temp)
 	return nil
 }
 
 // String returns MAASTime in RFC3339Nano format
-func (t *MAASTime) String() string {
-	return t.Format(time.RFC3339Nano)
+func (t MAASTime) String() string {
+	temp := time.Time(t)
+	return temp.Format(time.RFC3339Nano)
 }
 
 // MachineServiceSet represents a Machine's "service_set".

--- a/entity/machine_test.go
+++ b/entity/machine_test.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/maas/gomaasclient/test/helper"
@@ -16,5 +17,85 @@ func TestMachinet(t *testing.T) {
 	}
 	if err := helper.TestdataFromJSON("maas/machines.json", machines); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestMachineWithDeducedHwSync(t *testing.T) {
+	testcases := map[string]struct {
+		in  []byte
+		out bool
+	}{
+		"api returns no hw_sync data": {
+			in:  []byte(`{}`),
+			out: false,
+		},
+		"api returns enable_hw_sync true": {
+			in: []byte(`
+        {
+          "enable_hw_sync": true
+        }`,
+			),
+			out: true,
+		},
+		"api returns enable_hw_sync false": {
+			in: []byte(`
+        {
+          "enable_hw_sync": false
+        }`,
+			),
+			out: false,
+		},
+		"deduced enable_hw_sync true": {
+			in: []byte(`
+        {
+          "sync_interval": 900,
+          "next_sync": "2023-05-11T21:15:04.208",
+          "last_sync": "2023-05-11T21:00:04.208"
+        }`,
+			),
+			out: true,
+		},
+		"deduced enable_hw_sync false": {
+			in: []byte(`
+        {
+          "sync_interval": 0,
+          "next_sync": null,
+          "last_sync": null
+        }`,
+			),
+			out: false,
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			machine := Machine{}
+
+			if err := json.Unmarshal(tc.in, &machine); err != nil {
+				t.Fatal(err, string(tc.in))
+			}
+			if tc.out != machine.EnableHwSync {
+				t.Fatalf("expected %v, got %v", tc.out, machine.EnableHwSync)
+			}
+		})
+	}
+}
+
+func TestMAASTimeUnmarshalJSON(t *testing.T) {
+	temp := struct {
+		Time MAASTime
+	}{}
+
+	data := []byte(`{"Time": "2023-05-11T21:15:04.208"}`)
+	if err := json.Unmarshal(data, &temp); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "2023-05-11T21:15:04.208Z"
+	if temp.Time.String() != expected {
+		t.Fatalf("expected %v, got %v", expected, temp.Time.String())
 	}
 }


### PR DESCRIPTION
This is a follow up for https://github.com/maas/gomaasclient/pull/9

It seems to be a good idea exposing information whether hardware sync is enabled for the machine or not.
This functionality is available in MAAS 3.2+ but `enable_hw_sync` property was never exposed over API. However for machine with enabled hardware sync API returns `last_sync`, `sync_interval` and `next_sync` properties that can be used to deduce if hardware sync is enabled or not.

This PR adds proper JSON unmarshal for `enable_hw_sync` once this [MP](https://code.launchpad.net/~troyanov/maas/+git/maas/+merge/442692) will be merged, and in other scenarios it will deduce it from already available proeprties.