### PR TITLE
fix: remove enable_hw_sync from allocate

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -152,7 +152,6 @@ type MachineAllocateParams struct {
 	BridgeSTP        bool     `url:"bridge_stp,omitempty"`
 	DryRun           bool     `url:"dry_run,omitempty"`
 	Verbose          bool     `url:"verbose,omitempty"`
-	EnableHwSync     bool     `url:"enable_hw_sync,omitempty"`
 }
 
 // MachineDeployParams enumerates the parameters for the deploy operation


### PR DESCRIPTION
Allocate op doesn't support enable_hw_sync, according to https://maas.io/docs/api