### PR TITLE
Support op-accept_all API call

### DIFF
--- a/api/machines.go
+++ b/api/machines.go
@@ -8,5 +8,6 @@ type Machines interface {
 	Get() ([]entity.Machine, error)
 	Create(machineParams *entity.MachineParams, powerParams map[string]string) (*entity.Machine, error)
 	Allocate(params *entity.MachineAllocateParams) (*entity.Machine, error)
+	AcceptAll() error
 	Release(systemID []string, comment string) error
 }

--- a/client/machines.go
+++ b/client/machines.go
@@ -65,3 +65,8 @@ func (m *Machines) Release(systemIDs []string, comment string) error {
 	}
 	return m.client().Post("release", qsp, func(data []byte) error { return nil })
 }
+
+func (m *Machines) AcceptAll() error {
+	qsp := url.Values{}
+	return m.client().Post("accept_all", qsp, func(data []byte) error { return nil })
+}


### PR DESCRIPTION
Expose op-accept_all call via api in order to provide ability for newly discovered machines