### PR TITLE
Fix parsing of power parameters

### DIFF
--- a/api/machine.go
+++ b/api/machine.go
@@ -6,11 +6,11 @@ import (
 
 type Machine interface {
 	Get(systemID string) (*entity.Machine, error)
-	Update(systemID string, machineParams *entity.MachineParams, powerParams map[string]string) (*entity.Machine, error)
+	Update(systemID string, machineParams *entity.MachineParams, powerParams map[string]interface{}) (*entity.Machine, error)
 	Delete(systemID string) error
 	Commission(systemID string, params *entity.MachineCommissionParams) (*entity.Machine, error)
 	Deploy(systemID string, params *entity.MachineDeployParams) (*entity.Machine, error)
 	Lock(systemID string, comment string) (*entity.Machine, error)
 	ClearDefaultGateways(systemID string) (*entity.Machine, error)
-	GetPowerParameters(systemID string) (map[string]string, error)
+	GetPowerParameters(systemID string) (map[string]interface{}, error)
 }

--- a/api/machines.go
+++ b/api/machines.go
@@ -6,7 +6,7 @@ import (
 
 type Machines interface {
 	Get() ([]entity.Machine, error)
-	Create(machineParams *entity.MachineParams, powerParams map[string]string) (*entity.Machine, error)
+	Create(machineParams *entity.MachineParams, powerParams map[string]interface{}) (*entity.Machine, error)
 	Allocate(params *entity.MachineAllocateParams) (*entity.Machine, error)
 	AcceptAll() error
 	Release(systemID []string, comment string) error

--- a/client/machine.go
+++ b/client/machine.go
@@ -27,13 +27,14 @@ func (m *Machine) Get(systemID string) (ma *entity.Machine, err error) {
 }
 
 // Update machine.
-func (m *Machine) Update(systemID string, machineParams *entity.MachineParams, powerParams map[string]string) (ma *entity.Machine, err error) {
+func (m *Machine) Update(systemID string, machineParams *entity.MachineParams, powerParams map[string]interface{}) (ma *entity.Machine, err error) {
 	qsp, err := query.Values(machineParams)
 	if err != nil {
 		return
 	}
-	for k, v := range powerParams {
-		qsp.Add(k, v)
+	for k, v := range powerParamsToURLValues(powerParams) {
+		// Since qsp.Add(k, v...) is not allowed
+		qsp[k] = append(qsp[k], v...)
 	}
 	ma = new(entity.Machine)
 	err = m.client(systemID).Put(qsp, func(data []byte) error {
@@ -95,8 +96,8 @@ func (m *Machine) ClearDefaultGateways(systemID string) (ma *entity.Machine, err
 	return
 }
 
-func (m *Machine) GetPowerParameters(systemID string) (params map[string]string, err error) {
-	params = map[string]string{}
+func (m *Machine) GetPowerParameters(systemID string) (params map[string]interface{}, err error) {
+	params = map[string]interface{}{}
 	err = m.client(systemID).Get("power_parameters", url.Values{}, func(data []byte) error {
 		return json.Unmarshal(data, &params)
 	})

--- a/client/machines.go
+++ b/client/machines.go
@@ -26,13 +26,14 @@ func (m *Machines) Get() (machines []entity.Machine, err error) {
 }
 
 // Create machine.
-func (m *Machines) Create(machineParams *entity.MachineParams, powerParams map[string]string) (ma *entity.Machine, err error) {
+func (m *Machines) Create(machineParams *entity.MachineParams, powerParams map[string]interface{}) (ma *entity.Machine, err error) {
 	qsp, err := query.Values(machineParams)
 	if err != nil {
 		return
 	}
-	for k, v := range powerParams {
-		qsp.Add(k, v)
+	for k, v := range powerParamsToURLValues(powerParams) {
+		// Since qsp.Add(k, v...) is not allowed
+		qsp[k] = append(qsp[k], v...)
 	}
 	ma = new(entity.Machine)
 	err = m.client().Post("", qsp, func(data []byte) error {

--- a/client/utils.go
+++ b/client/utils.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+)
+
+// Converts power parameters to url.Values.
+// Supported power parameter value types: `string`, `int`, `bool`, `[]string`, `[]int`, `[]bool`
+func powerParamsToURLValues(params map[string]interface{}) url.Values {
+	qsp := url.Values{}
+
+	for k, v := range params {
+		val := reflect.ValueOf(v)
+		switch val.Kind() {
+		case reflect.String:
+			qsp.Add(k, v.(string))
+		case reflect.Int:
+			qsp.Add(k, fmt.Sprintf("%d", v.(int)))
+		case reflect.Bool:
+			qsp.Add(k, fmt.Sprintf("%t", v.(bool)))
+		case reflect.Slice:
+			for i := 0; i < val.Len(); i++ {
+				switch val.Index(0).Elem().Kind() {
+				case reflect.String:
+					qsp.Add(k, val.Index(i).Elem().String())
+				case reflect.Int:
+					qsp.Add(k, fmt.Sprintf("%d", val.Index(i).Elem().Int()))
+				case reflect.Bool:
+					qsp.Add(k, fmt.Sprintf("%t", val.Index(i).Elem().Bool()))
+				}
+			}
+		}
+	}
+	return qsp
+}

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPowerParamsToURLValues(t *testing.T) {
+	testcases := map[string]struct {
+		in  map[string]interface{}
+		out string
+	}{
+		"strings": {
+			in: map[string]interface{}{
+				"a": "b",
+				"c": "d",
+			},
+			out: "a=b&c=d",
+		},
+		"strings array": {
+			in: map[string]interface{}{
+				"a": []interface{}{"b", "c"},
+			},
+			out: "a=b&a=c",
+		},
+		"numbers": {
+			in: map[string]interface{}{
+				"a": 1,
+				"b": 2,
+			},
+			out: "a=1&b=2",
+		},
+		"numbers array": {
+			in: map[string]interface{}{
+				"a": []interface{}{1, 2},
+			},
+			out: "a=1&a=2",
+		},
+		"boolean": {
+			in: map[string]interface{}{
+				"a": true,
+				"b": false,
+			},
+			out: "a=true&b=false",
+		},
+		"boolean array": {
+			in: map[string]interface{}{
+				"a": []interface{}{true, false},
+			},
+			out: "a=true&a=false",
+		},
+	}
+
+	for name, tc := range testcases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			res := powerParamsToURLValues(tc.in).Encode()
+			assert.Equal(t, tc.out, res)
+		})
+	}
+}


### PR DESCRIPTION
Update power parameters to be `map[string]interface{}` instead of `map[string]string` to cover all type of parameters.

Being more specific, power parameters can also contain a key to `[]string` as it is happening with [IPMI](https://maas.io/docs/api#ipmi-ipmi) `workaround_flags`. This PR makes sure that a machine with IPMI can also be created/updated and that its power parameters can be fetched without an issue.