### PR TITLE
Fix network parameters

### DIFF
--- a/api/network_interface.go
+++ b/api/network_interface.go
@@ -7,7 +7,7 @@ import (
 // NetworkInterface represents the MaaS Server Interface endpoint
 type NetworkInterface interface {
 	Get(systemID string, id int) (*entity.NetworkInterface, error)
-	Update(systemID string, id int, params interface{}) (*entity.NetworkInterface, error)
+	Update(systemID string, id int, params *entity.NetworkInterfaceUpdateParams) (*entity.NetworkInterface, error)
 	Delete(systemID string, id int) error
 	Disconnect(systemID string, id int) (*entity.NetworkInterface, error)
 	AddTag(systemID string, id int, tag string) (*entity.NetworkInterface, error)

--- a/client/network_interface.go
+++ b/client/network_interface.go
@@ -36,7 +36,7 @@ func (n *NetworkInterface) Get(systemID string, id int) (networkInterface *entit
 	return
 }
 
-func (n *NetworkInterface) Update(systemID string, id int, params interface{}) (networkInterface *entity.NetworkInterface, err error) {
+func (n *NetworkInterface) Update(systemID string, id int, params *entity.NetworkInterfaceUpdateParams) (networkInterface *entity.NetworkInterface, err error) {
 	qsp, err := query.Values(params)
 	if err != nil {
 		return

--- a/entity/network_interface.go
+++ b/entity/network_interface.go
@@ -2,35 +2,35 @@ package entity
 
 // NetworkInterface represents the MaaS Interface endpoint.
 type NetworkInterface struct {
-	VLAN               VLAN                   `json:"vlan,omitempty"`
-	Children           []string               `json:"children,omitempty"`
-	Parents            []string               `json:"parents,omitempty"`
-	Tags               []string               `json:"tags,omitempty"`
-	Discovered         []NetworkInterfaceLink `json:"discovered,omitempty"`
-	Links              []NetworkInterfaceLink `json:"links,omitempty"`
-	Name               string                 `json:"name,omitempty"`
-	MACAddress         string                 `json:"mac_address,omitempty"`
-	Product            string                 `json:"product,omitempty"`
-	FirmwareVersion    string                 `json:"firmware_version,omitempty"`
-	SystemID           string                 `json:"system_id,omitempty"`
-	Params             interface{}            `json:"params,omitempty"`
-	Type               string                 `json:"type,omitempty"`
-	Vendor             string                 `json:"vendor,omitempty"`
-	ResourceURI        string                 `json:"resource_uri,omitempty"`
-	BondXMitHashPolicy string                 `json:"bond_x_mit_hash_policy,omitempty"`
-	BondMode           string                 `json:"bond_mode,omitempty"`
-	MTU                string                 `json:"mtu,omitempty"`
-	EffectiveMTU       int                    `json:"effective_mtu,omitempty"`
-	ID                 int                    `json:"id,omitempty"`
-	BridgeFD           int                    `json:"bridge_fd,omitempty"`
-	BondMIIMon         int                    `json:"bond_mii_mon,omitempty"`
-	BondDownDelay      int                    `json:"bond_down_delay,omitempty"`
-	BondUpDelay        int                    `json:"bond_up_delay,omitempty"`
-	BondLACPRate       int                    `json:"bond_lacp_rate,omitempty"`
-	AcceptRA           bool                   `json:"accept_ra,omitempty"`
-	Autoconf           bool                   `json:"autoconf,omitempty"`
-	Enabled            bool                   `json:"enabled,omitempty"`
-	BridgeSTP          bool                   `json:"bridge_stp,omitempty"`
+	VLAN            VLAN                           `json:"vlan,omitempty"`
+	Children        []string                       `json:"children,omitempty"`
+	Parents         []string                       `json:"parents,omitempty"`
+	Tags            []string                       `json:"tags,omitempty"`
+	Discovered      []NetworkInterfaceDiscoveredIP `json:"discovered,omitempty"`
+	Links           []NetworkInterfaceLink         `json:"links,omitempty"`
+	Name            string                         `json:"name,omitempty"`
+	MACAddress      string                         `json:"mac_address,omitempty"`
+	Product         string                         `json:"product,omitempty"`
+	FirmwareVersion string                         `json:"firmware_version,omitempty"`
+	SystemID        string                         `json:"system_id,omitempty"`
+	Params          interface{}                    `json:"params,omitempty"`
+	Type            string                         `json:"type,omitempty"`
+	Vendor          string                         `json:"vendor,omitempty"`
+	ResourceURI     string                         `json:"resource_uri,omitempty"`
+	EffectiveMTU    int                            `json:"effective_mtu,omitempty"`
+	ID              int                            `json:"id,omitempty"`
+	Enabled         bool                           `json:"enabled,omitempty"`
+	LinkConnected   bool                           `json:"link_connected,omitempty"`
+	InterfaceSpeed  int                            `json:"interface_speed,omitempty"`
+	LinkSpeed       int                            `json:"link_speed,omitempty"`
+	NUMANode        int                            `json:"numa_node,omitempty"`
+	SRIOVMaxVF      int                            `json:"sriov_max_vf,omitempty"`
+}
+
+// NetworkInterfaceDiscoveredIP is consumed by NetworkInterface{} and should not be used directly.
+type NetworkInterfaceDiscoveredIP struct {
+	Subnet    Subnet `json:"subnet,omitempty"`
+	IPAddress string `json:"ip_address,omitempty"`
 }
 
 // NetworkInterfaceLink is consumed by NetworkInterface{} and should not be used directly.
@@ -56,20 +56,31 @@ type NetworkInterfaceLinkParams struct {
 	IPAddress      string `url:"ip_address,omitempty"`
 }
 
-// NetworkInterfacePhysical is the parameters for the NetworkInterfaces create_physical POST operation.
-type NetworkInterfacePhysicalParams struct {
-	MACAddress string `url:"mac_address,omitempty"`
-	Name       string `url:"name,omitempty"`
-	Tags       string `url:"tags,omitempty"`
-	VLAN       string `url:"vlan,omitempty"`
-	MTU        int    `url:"mtu,omitempty"`
-	AcceptRA   bool   `url:"accept_ra,omitempty"`
-	Autoconf   bool   `url:"autoconf,omitempty"`
+// NetworkInterfaceParams is the common parameters for the NetworkInterfaces create_* POST operation.
+type NetworkInterfaceParams struct {
+	MTU            int      `url:"mtu,omitempty"`
+	AcceptRA       bool     `url:"accept_ra,omitempty"`
+	IPAssignment   string   `url:"ip_assignment,omitempty"`
+	IPAddress      string   `url:"ip_address,omitempty"`
+	LinkConnected  bool     `url:"link_connected,omitempty"`
+	InterfaceSpeed int      `url:"interface_speed,omitempty"`
+	LinkSpeed      int      `url:"link_speed,omitempty"`
+	VLAN           VLAN     `url:"vlan,omitempty"`
+	Tags           []string `url:"tags,omitempty"`
+	MACAddress     string   `url:"mac_address,omitempty"`
+	Name           string   `url:"name,omitempty"`
 }
 
-// NetworkInterfaceBond is the parameters for the NetworkInterfaces create_bond POST operation.
+// NetworkInterfacePhysicalParams is the parameters for the NetworkInterfaces create_physical POST operation.
+type NetworkInterfacePhysicalParams struct {
+	NetworkInterfaceParams
+	Enabled  bool `url:"enabled,omitempty"`
+	NUMANode int  `url:"numa_node,omitempty"`
+}
+
+// NetworkInterfaceBondParams is the parameters for the NetworkInterfaces create_bond POST operation.
 type NetworkInterfaceBondParams struct {
-	NetworkInterfacePhysicalParams
+	NetworkInterfaceParams
 	Parents            []int  `url:"parents,omitempty"`
 	BondMode           string `url:"bond_mode,omitempty"`
 	BondMiimon         int    `url:"bond_miimon,omitempty"`
@@ -80,21 +91,23 @@ type NetworkInterfaceBondParams struct {
 	BondNumberGratARP  int    `url:"bond_num_grat_arp,omitempty"`
 }
 
-// NetworkInterfaceBridge is the parameters for the NetworkInterfaces create_bridge POST operation.
+// NetworkInterfaceBridgeParams is the parameters for the NetworkInterfaces create_bridge POST operation.
 type NetworkInterfaceBridgeParams struct {
-	NetworkInterfacePhysicalParams
-	Parent     int    `url:"parent,omitempty"`
-	Bridgetype string `url:"bridge_type,omitempty"`
+	NetworkInterfaceParams
+	Parents    []int  `url:"parents,omitempty"`
+	BridgeType string `url:"bridge_type,omitempty"`
 	BridgeSTP  bool   `url:"bridge_stp,omitempty"`
 	BridgeFD   int    `url:"bridge_fd,omitempty"`
 }
 
-// NetworkInterfaceVLAN is the parameters for the NetworkInterfaces create_vlan POST operation.
+// NetworkInterfaceVLANParams is the parameters for the NetworkInterfaces create_vlan POST operation.
 type NetworkInterfaceVLANParams struct {
-	VLAN     string   `url:"vlan,omitempty"`
-	Parent   int      `url:"parent,omitempty"`
-	Tags     []string `url:"tags,omitempty"`
-	MTU      int      `url:"mtu,omitempty"`
-	AcceptRA bool     `url:"accept_ra,omitempty"`
-	Autoconf bool     `url:"autoconf,omitempty"`
+	NetworkInterfaceParams
+}
+
+// NetworkInterfaceUpdateParams is the parameters for the NetworkInterfaces update_bond POST operation.
+type NetworkInterfaceUpdateParams struct {
+	NetworkInterfaceBondParams
+	NetworkInterfaceBridgeParams
+	NetworkInterfaceVLANParams
 }

--- a/entity/network_interface_test.go
+++ b/entity/network_interface_test.go
@@ -25,7 +25,7 @@ var sampleNetworkInterface NetworkInterface = NetworkInterface{
 	Tags:            []string{},
 	Params:          map[string]interface{}{},
 	Type:            "physical",
-	Discovered:      []NetworkInterfaceLink{},
+	Discovered:      []NetworkInterfaceDiscoveredIP{},
 	EffectiveMTU:    1500,
 	Vendor:          "",
 	ID:              138,
@@ -63,7 +63,7 @@ var sampleNetworkInterfaces []NetworkInterface = []NetworkInterface{
 			"tag-QAxfJH",
 			"tag-VOqx2b",
 		},
-		Discovered: []NetworkInterfaceLink{},
+		Discovered: []NetworkInterfaceDiscoveredIP{},
 		ID:         37,
 		Links: []NetworkInterfaceLink{
 			{
@@ -139,7 +139,7 @@ var sampleNetworkInterfaces []NetworkInterface = []NetworkInterface{
 			"tag-EDi2sp",
 			"tag-RwynT2",
 		},
-		Discovered: []NetworkInterfaceLink{},
+		Discovered: []NetworkInterfaceDiscoveredIP{},
 		ID:         38,
 		Links: []NetworkInterfaceLink{
 			{
@@ -215,7 +215,7 @@ var sampleNetworkInterfaces []NetworkInterface = []NetworkInterface{
 			"tag-D71Hh0",
 			"tag-PnEfvN",
 		},
-		Discovered: []NetworkInterfaceLink{},
+		Discovered: []NetworkInterfaceDiscoveredIP{},
 		ID:         39,
 		Links: []NetworkInterfaceLink{
 			{
@@ -293,7 +293,7 @@ var sampleNetworkInterfaces []NetworkInterface = []NetworkInterface{
 			"tag-C09Efp",
 			"tag-QK7j09",
 		},
-		Discovered: []NetworkInterfaceLink{},
+		Discovered: []NetworkInterfaceDiscoveredIP{},
 		ID:         40,
 		Links: []NetworkInterfaceLink{
 			{
@@ -368,7 +368,7 @@ var sampleNetworkInterfaces []NetworkInterface = []NetworkInterface{
 			"tag-dxAebl",
 			"tag-GsPX3m",
 		},
-		Discovered: []NetworkInterfaceLink{},
+		Discovered: []NetworkInterfaceDiscoveredIP{},
 		ID:         41,
 		Links: []NetworkInterfaceLink{
 			{
@@ -444,7 +444,7 @@ var sampleNetworkInterfaces []NetworkInterface = []NetworkInterface{
 			"tag-nnoi80",
 			"tag-xhApes",
 		},
-		Discovered: []NetworkInterfaceLink{},
+		Discovered: []NetworkInterfaceDiscoveredIP{},
 		ID:         42,
 		Links: []NetworkInterfaceLink{
 			{


### PR DESCRIPTION
This PR includes the following:

- Update network interface fields which are different from the create/update parameters
- Introduce `NetworkInterfaceDiscoveredIP ` struct to represent `discovered` nested field of a network interface
- Update create parameters for each of the types physical, vlan, bridge, bond with proper fields and inheritance
- Introduce update parameters which can support the common interface update endpoint