### PR TITLE
fix: unmarshal number leads to int overflow

### DIFF
--- a/entity/block_device.go
+++ b/entity/block_device.go
@@ -9,12 +9,12 @@ type BlockDevice struct {
 	Name               string                 `json:"name,omitempty"`
 	Path               string                 `json:"path,omitempty"`
 	Serial             string                 `json:"serial,omitempty"`
-	Size               int                    `json:"size,omitempty"`
+	Size               int64                  `json:"size,omitempty"`
 	Tags               []string               `json:"tags,omitempty"`
 	FirmwareVersion    string                 `json:"firmware_version,omitempty"`
 	SystemID           string                 `json:"system_id,omitempty"`
-	AvailableSize      int                    `json:"available_size,omitempty"`
-	UsedSize           int                    `json:"used_size,omitempty"`
+	AvailableSize      int64                  `json:"available_size,omitempty"`
+	UsedSize           int64                  `json:"used_size,omitempty"`
 	PartitionTableType string                 `json:"partition_table_type,omitempty"`
 	Partitions         []BlockDevicePartition `json:"partitions,omitempty"`
 	Filesystem         PartitionFileSystem    `json:"filesystem,omitempty"`
@@ -27,7 +27,7 @@ type BlockDevice struct {
 
 type BlockDeviceParams struct {
 	Name      string `url:"name,omitempty"`
-	Size      int    `url:"size,omitempty"`
+	Size      int64  `url:"size,omitempty"`
 	BlockSize int    `url:"block_size,omitempty"`
 	UUID      string `url:"uuid,omitempty"`
 	Model     string `url:"model,omitempty"`

--- a/entity/block_device_partition.go
+++ b/entity/block_device_partition.go
@@ -3,7 +3,7 @@ package entity
 // BlockDevicePartition represents the MaaS block device partition endpoint.
 type BlockDevicePartition struct {
 	UUID        string              `json:"uuid"`
-	Size        int                 `json:"size"`
+	Size        int64               `json:"size"`
 	Bootable    bool                `json:"bootable"`
 	Tags        []string            `json:"tags,omitempty"`
 	SystemID    string              `json:"system_id"`
@@ -25,7 +25,7 @@ type PartitionFileSystem struct {
 }
 
 type BlockDevicePartitionParams struct {
-	Size     int    `url:"size,omitempty"`
+	Size     int64  `url:"size,omitempty"`
 	UUID     string `url:"uuid,omitempty"`
 	Bootable bool   `url:"bootable"`
 }

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -70,12 +70,12 @@ type Machine struct {
 	CPUTestStatusName            string                     `json:"cpu_test_status_name,omitempty"`
 	OtherTestStatusName          string                     `json:"other_test_status_name,omitempty"`
 	ResourceURI                  string                     `json:"resource_uri,omitempty"`
-	Memory                       int                        `json:"memory,omitempty"`
+	Memory                       int64                      `json:"memory,omitempty"`
 	NodeType                     int                        `json:"node_type,omitempty"`
 	CurrentCommissioningResultID int                        `json:"current_commissioning_result_id,omitempty"`
 	CPUTestStatus                int                        `json:"cpu_test_status,omitempty"`
 	AddressTTL                   int                        `json:"address_ttl,omitempty"`
-	Storage                      float64                    `json:"storage,omitempty"`
+	Storage                      int64                      `json:"storage,omitempty"`
 	HardwareInfo                 map[string]string          `json:"hardware_info,omitempty"`
 	CPUCount                     int                        `json:"cpu_count,omitempty"`
 	Status                       node.Status                `json:"status,omitempty"`
@@ -85,7 +85,7 @@ type Machine struct {
 	OtherTestStatus              int                        `json:"other_test_status,omitempty"`
 	TestingStatus                int                        `json:"testing_status,omitempty"`
 	StorageTestStatus            int                        `json:"storage_test_status,omitempty"`
-	SwapSize                     int                        `json:"swap_size,omitempty"`
+	SwapSize                     int64                      `json:"swap_size,omitempty"`
 	MemoryTestStatus             int                        `json:"memory_test_status,omitempty"`
 	CPUSpeed                     int                        `json:"cpu_speed,omitempty"`
 	DisableIPv4                  bool                       `json:"disable_ipv4,omitempty"`
@@ -192,8 +192,8 @@ type MachineServiceSet struct {
 // MachineParams enumerates the parameters for the machine update operation
 type MachineParams struct {
 	CPUCount      int    `url:"cpu_count,omitempty"`
-	Memory        int    `url:"memory,omitempty"`
-	SwapSize      int    `url:"swap_size,omitempty"`
+	Memory        int64  `url:"memory,omitempty"`
+	SwapSize      int64  `url:"swap_size,omitempty"`
 	PXEMacAddress string `url:"mac_addresses,omitempty"`
 	Architecture  string `url:"architecture,omitempty"`
 	MinHWEKernel  string `url:"min_hwe_kernel,omitempty"`
@@ -242,7 +242,7 @@ type MachineAllocateParams struct {
 	AgentName        string   `url:"agent_name,omitempty"`
 	Comment          string   `url:"comment,omitempty"`
 	CPUCount         int      `url:"cpu_count,omitempty"`
-	Mem              int      `url:"mem,omitempty"`
+	Mem              int64    `url:"mem,omitempty"`
 	BridgeFD         int      `url:"bridge_fd,omitempty"`
 	BridgeAll        bool     `url:"bridge_all,omitempty"`
 	BridgeSTP        bool     `url:"bridge_stp,omitempty"`

--- a/entity/vm_host.go
+++ b/entity/vm_host.go
@@ -31,18 +31,18 @@ type VMHostStoragePool struct {
 	Name      string `json:"name,omitempty"`
 	Type      string `json:"type,omitempty"`
 	Path      string `json:"path,omitempty"`
-	Total     int    `json:"total,omitempty"`
-	Used      int    `json:"used,omitempty"`
-	Available int    `json:"available,omitempty"`
+	Total     int64  `json:"total,omitempty"`
+	Used      int64  `json:"used,omitempty"`
+	Available int64  `json:"available,omitempty"`
 	Default   bool   `json:"default,omitempty"`
 }
 
 // VMHostResource represents the "used", "available", and "total" objects in a VMHost
 // This type should not be used directly.
 type VMHostResource struct {
-	Cores        int `json:"cores,omitempty"`
-	Memory       int `json:"memory,omitempty"`
-	LocalStorage int `json:"local_storage,omitempty"`
+	Cores        int   `json:"cores,omitempty"`
+	Memory       int64 `json:"memory,omitempty"`
+	LocalStorage int64 `json:"local_storage,omitempty"`
 }
 
 // VMHostParams enumerates the VMHost configuration options.
@@ -65,7 +65,7 @@ type VMHostParams struct {
 type VMHostMachineParams struct {
 	Cores           int    `url:"cores,omitempty"`
 	PinnedCores     int    `url:"pinned_cores,omitempty"`
-	Memory          int    `url:"memory,omitempty"`
+	Memory          int64  `url:"memory,omitempty"`
 	HugepagesBacked bool   `url:"hugepages_backed,omitempty"`
 	Architecture    string `url:"architecture,omitempty"`
 	Storage         string `url:"storage,omitempty"`

--- a/entity/volume_group.go
+++ b/entity/volume_group.go
@@ -2,18 +2,17 @@ package entity
 
 // VolumeGroup represents the MaaS VolumeGroup endpoint.
 type VolumeGroup struct {
-    HumanUsedSize      string                      `json:"human_used_size,omitempty"`
-    UUID               string                      `json:"uuid,omitempty"`
-    HumanAvailableSize string                      `json:"human_available_size,omitempty"`
-    SystemID           string                      `json:"system_id,omitempty"`
-    ID                 int                         `json:"id,omitempty"`
-    LogicalVolumes     interface{}                 `json:"logical_volumes,omitempty"`
-    Size               int                         `json:"size,omitempty"`
-    Devices            interface{}                 `json:"devices,omitempty"`
-    AvailableSize      int                         `json:"available_size,omitempty"`
-    UsedSize           int                         `json:"used_size,omitempty"`
-    HumanSize          string                      `json:"human_size,omitempty"`
-    Name               string                      `json:"name,omitempty"`
-    ResourceURI        string                      `json:"resource_uri,omitempty"`
+	HumanUsedSize      string      `json:"human_used_size,omitempty"`
+	UUID               string      `json:"uuid,omitempty"`
+	HumanAvailableSize string      `json:"human_available_size,omitempty"`
+	SystemID           string      `json:"system_id,omitempty"`
+	ID                 int         `json:"id,omitempty"`
+	LogicalVolumes     interface{} `json:"logical_volumes,omitempty"`
+	Size               int64       `json:"size,omitempty"`
+	Devices            interface{} `json:"devices,omitempty"`
+	AvailableSize      int64       `json:"available_size,omitempty"`
+	UsedSize           int64       `json:"used_size,omitempty"`
+	HumanSize          string      `json:"human_size,omitempty"`
+	Name               string      `json:"name,omitempty"`
+	ResourceURI        string      `json:"resource_uri,omitempty"`
 }
-


### PR DESCRIPTION
Use `int64` type for disk size.

Resolves https://github.com/maas/terraform-provider-maas/issues/116

When compiled on a 32-bit platform `int` will be `int32` and will lead to an overflow and JSON unmarshal error:

```go
type Foo struct {
	Size int32
}

func main() {
	data := []byte(`{"Size": 128032178176}`)
	foo := Foo{}
	err := json.Unmarshal(data, &foo)
	if err != nil {
		fmt.Println(err)
	}
	fmt.Println(foo.Size)
}
```