### PR TITLE
Add release machine operation

### DIFF
--- a/api/machine.go
+++ b/api/machine.go
@@ -10,6 +10,7 @@ type Machine interface {
 	Delete(systemID string) error
 	Commission(systemID string, params *entity.MachineCommissionParams) (*entity.Machine, error)
 	Deploy(systemID string, params *entity.MachineDeployParams) (*entity.Machine, error)
+	Release(systemID string, params *entity.MachineReleaseParams) (*entity.Machine, error)
 	Lock(systemID string, comment string) (*entity.Machine, error)
 	ClearDefaultGateways(systemID string) (*entity.Machine, error)
 	GetPowerParameters(systemID string) (map[string]interface{}, error)

--- a/client/machine.go
+++ b/client/machine.go
@@ -74,6 +74,19 @@ func (m *Machine) Deploy(systemID string, params *entity.MachineDeployParams) (m
 	return
 }
 
+// Release machine.
+func (m *Machine) Release(systemID string, params *entity.MachineReleaseParams) (ma *entity.Machine, err error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return
+	}
+	ma = new(entity.Machine)
+	err = m.client(systemID).Post("release", qsp, func(data []byte) error {
+		return json.Unmarshal(data, ma)
+	})
+	return
+}
+
 // Lock machine.
 func (m *Machine) Lock(systemID string, comment string) (ma *entity.Machine, err error) {
 	qsp := make(url.Values)

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -265,3 +265,12 @@ type MachineDeployParams struct {
 	RegisterVMHost bool   `url:"register_vmhost,omitempty"`
 	EnableHwSync   bool   `url:"enable_hw_sync,omitempty"`
 }
+
+// MachineDeployParams enumerates the parameters for the release operation
+type MachineReleaseParams struct {
+	Comment     string `url:"comment,omitempty"`
+	Erase       string `url:"erase,omitempty"`
+	Force       string `url:"force,omitempty"`
+	QuickErase  string `url:"quick_erase,omitempty"`
+	SecureErase string `url:"secure_erase,omitempty"`
+}


### PR DESCRIPTION
This PR adds the option to release a single machine through the `gomaasclient` so as to enable erase disk functionality which is currently missing from the Terraform provider