### PR TITLE
Fix params for release api

### DIFF
--- a/entity/machine.go
+++ b/entity/machine.go
@@ -266,7 +266,7 @@ type MachineDeployParams struct {
 	EnableHwSync   bool   `url:"enable_hw_sync,omitempty"`
 }
 
-// MachineDeployParams enumerates the parameters for the release operation
+// MachineReleaseParams enumerates the parameters for the release operation
 type MachineReleaseParams struct {
 	Comment     string `url:"comment,omitempty"`
 	Erase       bool   `url:"erase,omitempty"`

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -269,8 +269,8 @@ type MachineDeployParams struct {
 // MachineDeployParams enumerates the parameters for the release operation
 type MachineReleaseParams struct {
 	Comment     string `url:"comment,omitempty"`
-	Erase       string `url:"erase,omitempty"`
-	Force       string `url:"force,omitempty"`
-	QuickErase  string `url:"quick_erase,omitempty"`
-	SecureErase string `url:"secure_erase,omitempty"`
+	Erase       bool   `url:"erase,omitempty"`
+	Force       bool   `url:"force,omitempty"`
+	QuickErase  bool   `url:"quick_erase,omitempty"`
+	SecureErase bool   `url:"secure_erase,omitempty"`
 }


### PR DESCRIPTION
as per API documentation the release params needs to boolean However, currently it is being used as string