### PR TITLE
feat: add boot related entities and API endpoint interactions

### DIFF
--- a/api/boot_resource.go
+++ b/api/boot_resource.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootResource is an interface defining API behaviour for
+// boot resources
+type BootResource interface {
+	Get(id int) (*entity.BootResource, error)
+	Delete(id int) error
+}

--- a/api/boot_resources.go
+++ b/api/boot_resources.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootResources is an interface for listing and creating
+// BootResource objects
+type BootResources interface {
+	Get(params *entity.BootResourcesReadParams) ([]entity.BootResource, error)
+	Create(params *entity.BootResourceParams) (*entity.BootResource, error)
+	Import() error
+	IsImporting() (bool, error)
+	StopImport() error
+}

--- a/api/boot_source.go
+++ b/api/boot_source.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSource is an interface defining API behaviour for
+// boot sources
+type BootSource interface {
+	Get(id int) (*entity.BootSource, error)
+	Update(id int, params *entity.BootSourceParams) (*entity.BootSource, error)
+	Delete(id int) error
+}

--- a/api/boot_source_selection.go
+++ b/api/boot_source_selection.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSourceSelection is an interface defining API behaviour for
+// boot source selections
+type BootSourceSelection interface {
+	Get(bootSourceID int, id int) (*entity.BootSourceSelection, error)
+	Update(bootSourceID int, id int, params *entity.BootSourceSelectionParams) (*entity.BootSourceSelection, error)
+	Delete(bootSourceID int, id int) error
+}

--- a/api/boot_source_selections.go
+++ b/api/boot_source_selections.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSourceSelections is an interface for listing and creating
+// BootSourceSelection objects
+type BootSourceSelections interface {
+	Get(bootSourceID int) ([]entity.BootSourceSelection, error)
+	Create(bootSourceID int, params *entity.BootSourceSelectionParams) (*entity.BootSourceSelection, error)
+}

--- a/api/boot_sources.go
+++ b/api/boot_sources.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSources is an interface for listing and creating
+// BootSource objects
+type BootSources interface {
+	Get() ([]entity.BootSource, error)
+	Create(params *entity.BootSourceParams) (*entity.BootSource, error)
+}

--- a/client/boot_resource.go
+++ b/client/boot_resource.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootResource implements api.BootResource
+type BootResource struct {
+	APIClient APIClient
+}
+
+func (b *BootResource) client(id int) APIClient {
+	return b.APIClient.GetSubObject("boot-resources").GetSubObject(fmt.Sprintf("%v", id))
+}
+
+// Get fetches a boot resource with a given id
+func (b *BootResource) Get(id int) (*entity.BootResource, error) {
+	bootResource := new(entity.BootResource)
+	err := b.client(id).Get("", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, bootResource)
+	})
+
+	return bootResource, err
+}
+
+// Delete deletes a given boot resource
+func (b *BootResource) Delete(id int) error {
+	return b.client(id).Delete()
+}

--- a/client/boot_resources.go
+++ b/client/boot_resources.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootResources implements api.BootResources
+type BootResources struct {
+	APIClient APIClient
+}
+
+func (b *BootResources) client() APIClient {
+	return b.APIClient.GetSubObject("boot-resources")
+}
+
+// Get fetches a list of boot resources
+func (b *BootResources) Get(params *entity.BootResourcesReadParams) ([]entity.BootResource, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bootResources := make([]entity.BootResource, 0)
+	err = b.client().Get("", qsp, func(data []byte) error {
+		return json.Unmarshal(data, &bootResources)
+	})
+
+	return bootResources, err
+}
+
+// Create creates a new boot source
+func (b *BootResources) Create(params *entity.BootResourceParams) (*entity.BootResource, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Import imports boot resources to rack controllers
+func (b *BootResources) Import() error {
+	return b.client().Post("import", url.Values{}, func(data []byte) error {
+		return nil
+	})
+}
+
+// IsImporting returns importing status of boot resources importing to rack controllers
+func (b *BootResources) IsImporting() (bool, error) {
+	isImporting := new(bool)
+	err := b.client().Get("is-importing", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, isImporting)
+	})
+
+	return *isImporting, err
+}
+
+// StopImport stops importing boot resources to rack controllers
+func (b *BootResources) StopImport() error {
+	return b.client().Post("stop-import", url.Values{}, func(data []byte) error {
+		return nil
+	})
+}

--- a/client/boot_source.go
+++ b/client/boot_source.go
@@ -1,0 +1,50 @@
+//nolint:dupl // disable dupl check on client for now
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSource implements api.BootSource
+type BootSource struct {
+	APIClient APIClient
+}
+
+func (b *BootSource) client(id int) APIClient {
+	return b.APIClient.GetSubObject("boot-sources").GetSubObject(fmt.Sprintf("%v", id))
+}
+
+// Get fetches a boot source with a given id
+func (b *BootSource) Get(id int) (*entity.BootSource, error) {
+	bootSource := new(entity.BootSource)
+	err := b.client(id).Get("", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, bootSource)
+	})
+
+	return bootSource, err
+}
+
+// Update updates a given boot source
+func (b *BootSource) Update(id int, params *entity.BootSourceParams) (*entity.BootSource, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bootSource := new(entity.BootSource)
+	err = b.client(id).Put(qsp, func(data []byte) error {
+		return json.Unmarshal(data, bootSource)
+	})
+
+	return bootSource, err
+}
+
+// Delete deletes a given boot source
+func (b *BootSource) Delete(id int) error {
+	return b.client(id).Delete()
+}

--- a/client/boot_source_selection.go
+++ b/client/boot_source_selection.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSourceSelection implements api.BootSourceSelection
+type BootSourceSelection struct {
+	APIClient APIClient
+}
+
+func (b *BootSourceSelection) client(bootSourceID int, id int) APIClient {
+	return b.APIClient.GetSubObject("boot-sources").
+		GetSubObject(fmt.Sprintf("%v", bootSourceID)).
+		GetSubObject("selections").
+		GetSubObject(fmt.Sprintf("%v", id))
+}
+
+// Get fetches a BootSourceSelection for the given bootSourceID and BootSourceSelection id
+func (b *BootSourceSelection) Get(bootSourceID int, id int) (*entity.BootSourceSelection, error) {
+	bootSourceSelection := new(entity.BootSourceSelection)
+	err := b.client(bootSourceID, id).Get("", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, bootSourceSelection)
+	})
+
+	return bootSourceSelection, err
+}
+
+// Update updates a given BootSourceSelection
+func (b *BootSourceSelection) Update(bootSourceID int, id int, params *entity.BootSourceSelectionParams) (*entity.BootSourceSelection, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bootSourceSelection := new(entity.BootSourceSelection)
+	err = b.client(bootSourceID, id).Put(qsp, func(data []byte) error {
+		return json.Unmarshal(data, bootSourceSelection)
+	})
+
+	return bootSourceSelection, err
+}
+
+// Delete deletes a given BootSourceSelection
+func (b *BootSourceSelection) Delete(bootSourceID int, id int) error {
+	return b.client(bootSourceID, id).Delete()
+}

--- a/client/boot_source_selections.go
+++ b/client/boot_source_selections.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSourceSelections implements api.BootSourceSelections
+type BootSourceSelections struct {
+	APIClient APIClient
+}
+
+func (b *BootSourceSelections) client(bootSourceID int) APIClient {
+	return b.APIClient.GetSubObject("boot-sources").
+		GetSubObject(fmt.Sprintf("%v", bootSourceID)).
+		GetSubObject("selections")
+}
+
+// Get fetches a list of BootSourceSelection objects
+func (b *BootSourceSelections) Get(bootSourceID int) ([]entity.BootSourceSelection, error) {
+	bootSourceSelections := make([]entity.BootSourceSelection, 0)
+	err := b.client(bootSourceID).Get("", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, &bootSourceSelections)
+	})
+
+	return bootSourceSelections, err
+}
+
+// Create creates a BootSourceSelection object
+func (b *BootSourceSelections) Create(bootSourceID int, params *entity.BootSourceSelectionParams) (*entity.BootSourceSelection, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bootSourceSelection := new(entity.BootSourceSelection)
+	err = b.client(bootSourceID).Post("", qsp, func(data []byte) error {
+		return json.Unmarshal(data, bootSourceSelection)
+	})
+
+	return bootSourceSelection, err
+}

--- a/client/boot_sources.go
+++ b/client/boot_sources.go
@@ -1,0 +1,44 @@
+//nolint:dupl // disable dupl check on client for now
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+)
+
+// BootSources implements api.BootSources
+type BootSources struct {
+	APIClient APIClient
+}
+
+func (b *BootSources) client() APIClient {
+	return b.APIClient.GetSubObject("boot-sources")
+}
+
+// Get fetches a list of boot sources
+func (b *BootSources) Get() ([]entity.BootSource, error) {
+	bootSources := make([]entity.BootSource, 0)
+	err := b.client().Get("", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, &bootSources)
+	})
+
+	return bootSources, err
+}
+
+// Create creates a new boot source
+func (b *BootSources) Create(params *entity.BootSourceParams) (*entity.BootSource, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	bootSource := new(entity.BootSource)
+	err = b.client().Post("", qsp, func(data []byte) error {
+		return json.Unmarshal(data, bootSource)
+	})
+
+	return bootSource, err
+}

--- a/client/client.go
+++ b/client/client.go
@@ -72,6 +72,12 @@ func constructClient(apiClient *APIClient) *Client {
 		MAASServer:            &MAASServer{APIClient: *apiClient},
 		PackageRepository:     &PackageRepository{APIClient: *apiClient},
 		PackageRepositories:   &PackageRepositories{APIClient: *apiClient},
+		BootSource:            &BootSource{APIClient: *apiClient},
+		BootSources:           &BootSources{APIClient: *apiClient},
+		BootSourceSelection:   &BootSourceSelection{APIClient: *apiClient},
+		BootSourceSelections:  &BootSourceSelections{APIClient: *apiClient},
+		BootResource:          &BootResource{APIClient: *apiClient},
+		BootResources:         &BootResources{APIClient: *apiClient},
 	}
 
 	return &client
@@ -120,6 +126,12 @@ type Client struct {
 	MAASServer            api.MAASServer
 	PackageRepository     api.PackageRepository
 	PackageRepositories   api.PackageRepositories
+	BootSource            api.BootSource
+	BootSources           api.BootSources
+	BootSourceSelection   api.BootSourceSelection
+	BootSourceSelections  api.BootSourceSelections
+	BootResource          api.BootResource
+	BootResources         api.BootResources
 }
 
 // GetAPIClient returns a MAAS API client.

--- a/entity/boot_resource.go
+++ b/entity/boot_resource.go
@@ -1,0 +1,47 @@
+package entity
+
+type BootResource struct {
+	Sets         map[string]BootResourceSet `json:"sets,omitempty"`
+	Type         string                     `json:"type,omitempty"`
+	Name         string                     `json:"name,omitempty"`
+	Architecture string                     `json:"architecture,omitempty"`
+	ResourceURI  string                     `json:"resource_uri,omitempty"`
+	LastDeployed string                     `json:"last_deployed,omitempty"`
+	Subarches    string                     `json:"subarches,omitempty"`
+	ID           int                        `json:"id,omitempty"`
+}
+
+type BootResourceParams struct {
+	Name         string `url:"name,omitempty"`
+	Architecture string `url:"architecture,omitempty"`
+	SHA256       string `url:"sha256,omitempty"`
+	Size         string `url:"size,omitempty"`
+	Title        string `url:"title,omitempty"`
+	Filetype     string `url:"filetype,omitempty"`
+	BaseImage    string `url:"base_image,omitempty"`
+	Content      string `url:"content,omitempty"`
+}
+
+type BootResourcesReadParams struct {
+	Type string `json:"type,omitempty"`
+}
+
+// BootResourceSet represents a BootResource's "set".
+// This type should not be used directly.
+type BootResourceSet struct {
+	Files    map[string]BootResourceSetFile `json:"files,omitempty"`
+	Version  string                         `json:"version,omitempty"`
+	Label    string                         `json:"label,omitempty"`
+	Size     int64                          `json:"size,omitempty"`
+	Complete bool                           `json:"complete,omitempty"`
+}
+
+// BootResourceSetFile represents a BootResource set's "file".
+// This type should not be used directly.
+type BootResourceSetFile struct {
+	Filename string `json:"filename,omitempty"`
+	Filetype string `json:"filetype,omitempty"`
+	SHA256   string `json:"sha256,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+	Complete bool   `json:"complete,omitempty"`
+}

--- a/entity/boot_source.go
+++ b/entity/boot_source.go
@@ -1,0 +1,17 @@
+package entity
+
+type BootSource struct {
+	Created         string `json:"created,omitempty"`
+	Updated         string `json:"updated,omitempty"`
+	URL             string `json:"url,omitempty"`
+	KeyringFilename string `json:"keyring_filename,omitempty"`
+	KeyringData     string `json:"keyring_data,omitempty"`
+	ResourceURI     string `json:"resource_uri,omitempty"`
+	ID              int    `json:"id,omitempty"`
+}
+
+type BootSourceParams struct {
+	KeyringData     string `url:"keyring_data,omitempty"`
+	KeyringFilename string `url:"keyring_filename,omitempty"`
+	URL             string `url:"url,omitempty"`
+}

--- a/entity/boot_source_selection.go
+++ b/entity/boot_source_selection.go
@@ -1,0 +1,20 @@
+package entity
+
+type BootSourceSelection struct {
+	OS           string   `json:"os,omitempty"`
+	Release      string   `json:"release,omitempty"`
+	ResourceURI  string   `json:"resource_uri,omitempty"`
+	Arches       []string `json:"arches,omitempty"`
+	Subarches    []string `json:"subarches,omitempty"`
+	Labels       []string `json:"labels,omitempty"`
+	ID           int      `json:"id,omitempty"`
+	BootSourceID int      `json:"boot_source_id,omitempty"`
+}
+
+type BootSourceSelectionParams struct {
+	OS        string   `url:"os,omitempty"`
+	Release   string   `url:"release,omitempty"`
+	Arches    []string `url:"arches,omitempty"`
+	Subarches []string `url:"subarches,omitempty"`
+	Labels    []string `url:"labels,omitempty"`
+}


### PR DESCRIPTION
Include the following boot entities:

- Boot sources
- Boot source selections
- Boot resources

NOTE: Creation of a custom boot resource has not been implemented as it requires special handling with file contents, which is different than the underlying `gomaasapi` implementation [CallPostFiles](https://github.com/juju/gomaasapi/blob/master/maasobject.go#L190).