### PR TITLE
feat: add power parameters for LXD hosts

### DIFF
--- a/client/vm_host.go
+++ b/client/vm_host.go
@@ -70,8 +70,12 @@ func (p *VMHost) Compose(id int, params *entity.VMHostMachineParams) (*entity.Ma
 
 // Refresh refreshes resource info and VM status of a given VMHost
 func (p *VMHost) Refresh(id int) (*entity.VMHost, error) {
-	err := p.client(id).Post("refresh", url.Values{}, func(data []byte) error { return nil })
-	return nil, err
+	vmHost := new(entity.VMHost)
+	err := p.client(id).Post("refresh", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, vmHost)
+	})
+
+	return vmHost, err
 }
 
 // GetParameters fetches the configured parameters of a given VMHost

--- a/entity/vm_host.go
+++ b/entity/vm_host.go
@@ -47,18 +47,20 @@ type VMHostResource struct {
 
 // VMHostParams enumerates the VMHost configuration options.
 type VMHostParams struct {
+	Pool                  string  `url:"pool,omitempty"`
 	Type                  string  `url:"type,omitempty"`
-	PowerAddress          string  `url:"power_address,omitempty"`
 	PowerUser             string  `url:"power_user,omitempty"`
 	PowerPass             string  `url:"power_pass,omitempty"`
 	Name                  string  `url:"name,omitempty"`
 	Zone                  string  `url:"zone,omitempty"`
-	Pool                  string  `url:"pool,omitempty"`
+	PowerAddress          string  `url:"power_address,omitempty"`
 	DefaultStoragePool    string  `url:"default_storage_pool,omitempty"`
-	DefaultMacvlanMode    string  `url:"default_macvlan_mode,omitempty"`
+	Key                   string  `url:"key,omitempty"`
 	Tags                  string  `url:"tags,omitempty"`
-	CPUOverCommitRatio    float64 `url:"cpu_over_commit_ratio,omitempty"`
+	DefaultMacvlanMode    string  `url:"default_macvlan_mode,omitempty"`
+	Certificate           string  `url:"certificate,omitempty"`
 	MemoryOverCommitRatio float64 `url:"memory_over_commit_ratio,omitempty"`
+	CPUOverCommitRatio    float64 `url:"cpu_over_commit_ratio,omitempty"`
 }
 
 // VMHostMachineParams enumerates the VMHost machine configuration options.


### PR DESCRIPTION
This PR includes:

- Addition of `key`, `certificate` parameters to add LXD hosts with existing credentials
- Consumption of the VM host refresh result data