### PR TITLE
feat: add MAAS server API endpoint interactions

### DIFF
--- a/api/maas_server.go
+++ b/api/maas_server.go
@@ -2,6 +2,6 @@ package api
 
 // MAASServer represents the MAAS Server endpoint for changing global configuration settings
 type MAASServer interface {
-	Get(name string) (value string, err error)
+	Get(name string) (value []byte, err error)
 	Post(name, value string) error
 }

--- a/client/client.go
+++ b/client/client.go
@@ -69,6 +69,7 @@ func constructClient(apiClient *APIClient) *Client {
 		Users:                 &Users{APIClient: *apiClient},
 		ResourcePool:          &ResourcePool{APIClient: *apiClient},
 		ResourcePools:         &ResourcePools{APIClient: *apiClient},
+		MAASServer:            &MAASServer{APIClient: *apiClient},
 	}
 
 	return &client
@@ -114,6 +115,7 @@ type Client struct {
 	Users                 api.Users
 	ResourcePool          api.ResourcePool
 	ResourcePools         api.ResourcePools
+	MAASServer            api.MAASServer
 }
 
 // GetAPIClient returns a MAAS API client.

--- a/client/maas_server.go
+++ b/client/maas_server.go
@@ -1,0 +1,41 @@
+package client
+
+import (
+	"net/url"
+)
+
+// MAASServer contains functionality for manipulating the MAASServer entity.
+type MAASServer struct {
+	APIClient APIClient
+}
+
+func (m *MAASServer) client() APIClient {
+	return m.APIClient.GetSubObject("maas")
+}
+
+// Get MAAS server configuration value.
+func (m *MAASServer) Get(name string) ([]byte, error) {
+	qsp := url.Values{}
+	qsp.Set("name", name)
+
+	value := new([]byte)
+	err := m.client().Get("get_config", qsp, func(data []byte) error {
+		*value = data
+		return nil
+	})
+
+	return *value, err
+}
+
+// Post (Set) MAAS server configuration value.
+func (m *MAASServer) Post(name, value string) error {
+	qsp := url.Values{}
+	qsp.Set("name", name)
+	qsp.Set("value", value)
+
+	err := m.client().Post("set_config", qsp, func(data []byte) error {
+		return nil
+	})
+
+	return err
+}


### PR DESCRIPTION
This PR includes the following:

- Update the initial interface signature so that Get can return a byte slice. This is needed since get can return a mixture of int, string or boolean values
- Implement the existing API
- Expose the API interaction through the client

**NOTE:** It is user responsibility to unmarshal the returned value to an appropriate type.