### PR TITLE
feat: add machine details API endpoint interaction

### DIFF
--- a/api/machine.go
+++ b/api/machine.go
@@ -26,4 +26,5 @@ type Machine interface {
 	MarkBroken(systemID string, comment string) (*entity.Machine, error)
 	MarkFixed(systemID string, comment string) (*entity.Machine, error)
 	GetToken(systemID string) (*entity.MachineToken, error)
+	Details(systemID string) (*entity.MachineDetails, error)
 }

--- a/client/machine.go
+++ b/client/machine.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/maas/gomaasclient/entity"
+	"gopkg.in/mgo.v2/bson"
 )
 
 // Machine contains functionality for manipulating the Machine entity.
@@ -275,4 +276,13 @@ func (m *Machine) GetToken(systemID string) (*entity.MachineToken, error) {
 	})
 
 	return machineToken, err
+}
+
+func (m *Machine) Details(systemID string) (*entity.MachineDetails, error) {
+	machineDetails := new(entity.MachineDetails)
+	err := m.client(systemID).Get("details", url.Values{}, func(data []byte) error {
+		return bson.Unmarshal(data, machineDetails)
+	})
+
+	return machineDetails, err
 }

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -302,3 +302,8 @@ type MachinePowerOffParams struct {
 	Comment  string `url:"comment,omitempty"`
 	StopMode string `url:"stop_mode,omitempty"`
 }
+
+type MachineDetails struct {
+	LLDP string `json:"lldp,omitempty"`
+	LSHW string `json:"lshw,omitempty"`
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-querystring v1.1.0
 	github.com/juju/gomaasapi/v2 v2.2.0
 	github.com/stretchr/testify v1.8.4
+	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v1 v1.0.0-20161222125816-442357a80af5/go.mod h1:u0ALmqvLRxLI95fkdCEWrE6mhWYZW1aMOJHp5YXLHTg=
 gopkg.in/httprequest.v1 v1.1.1/go.mod h1:/CkavNL+g3qLOrpFHVrEx4NKepeqR4XTZWNj4sGGjz0=
 gopkg.in/mgo.v2 v2.0.0-20160818015218-f2b6f6c918c4/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=


### PR DESCRIPTION
Add endpoint for machine details that is fetching the bson response and unmarshal it before returning the data to the user.

**NOTE:** Both lldp and lshw are valid XML but intentionally their unmarshaling is not performed so that user can parse them as desired.