### PR TITLE
Add constructor with pluggable transport

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,18 +3,19 @@ package client
 
 import (
 	"crypto/tls"
-	"net/http"
-	"net/url"
-
 	gomaasapi "github.com/juju/gomaasapi/v2"
 	"github.com/maas/gomaasclient/api"
+	"net/http"
+	"net/url"
 )
 
 // GetTLSClient creates a Client configured with TLS
 func GetTLSClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tls.Config) (*Client, error) {
 	var tr http.RoundTripper
 	if tlsConfig != nil {
-		tr = &http.Transport{TLSClientConfig: tlsConfig}
+		defaultTransportCopy := http.DefaultTransport.(*http.Transport).Clone()
+		defaultTransportCopy.TLSClientConfig = tlsConfig
+		tr = defaultTransportCopy
 	}
 
 	apiClient, err := getAPIClient(apiURL, apiKey, apiVersion, tr)

--- a/client/client.go
+++ b/client/client.go
@@ -191,7 +191,7 @@ func getAPIClient(apiURL string, apiKey string, apiVersion string, tr http.Round
 	}
 
 	if tr == nil {
-		tr = &http.Transport{}
+		tr = http.DefaultTransport
 	}
 
 	httpClient := &http.Client{Transport: tr}

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,7 @@ import (
 
 // GetTLSClient creates a Client configured with TLS
 func GetTLSClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tls.Config) (*Client, error) {
-	var tr *http.Transport
+	var tr http.RoundTripper
 	if tlsConfig != nil {
 		tr = &http.Transport{TLSClientConfig: tlsConfig}
 	}
@@ -37,7 +37,7 @@ func GetClient(apiURL string, apiKey string, apiVersion string) (*Client, error)
 }
 
 // GetClientWithTransport creates a Client configured with the specified http.Transport
-func GetClientWithTransport(apiURL string, apiKey string, apiVersion string, tr *http.Transport) (*Client, error) {
+func GetClientWithTransport(apiURL string, apiKey string, apiVersion string, tr http.RoundTripper) (*Client, error) {
 	apiClient, err := getAPIClient(apiURL, apiKey, apiVersion, tr)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func GetAPIClient(apiURL string, apiKey string, apiVersion string) (*APIClient, 
 	return getAPIClient(apiURL, apiKey, apiVersion, nil)
 }
 
-func getAPIClient(apiURL string, apiKey string, apiVersion string, tr *http.Transport) (*APIClient, error) {
+func getAPIClient(apiURL string, apiKey string, apiVersion string, tr http.RoundTripper) (*APIClient, error) {
 	versionedURL := gomaasapi.AddAPIVersionToURL(apiURL, apiVersion)
 
 	authClient, err := gomaasapi.NewAuthenticatedClient(versionedURL, apiKey)

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,13 @@ import (
 
 // GetTLSClient creates a Client configured with TLS
 func GetTLSClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tls.Config) (*Client, error) {
-	apiClient, err := getAPIClient(apiURL, apiKey, apiVersion, tlsConfig)
+	var tr *http.Transport
+	if tlsConfig != nil {
+		tr = &http.Transport{TLSClientConfig: tlsConfig}
+	}
+
+	apiClient, err := getAPIClient(apiURL, apiKey, apiVersion, tr)
+
 	if err != nil {
 		return nil, err
 	}
@@ -23,6 +29,16 @@ func GetTLSClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tl
 // GetClient creates a client
 func GetClient(apiURL string, apiKey string, apiVersion string) (*Client, error) {
 	apiClient, err := getAPIClient(apiURL, apiKey, apiVersion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return constructClient(apiClient), nil
+}
+
+// GetClientWithTransport creates a Client configured with the specified http.Transport
+func GetClientWithTransport(apiURL string, apiKey string, apiVersion string, tr *http.Transport) (*Client, error) {
+	apiClient, err := getAPIClient(apiURL, apiKey, apiVersion, tr)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +182,7 @@ func GetAPIClient(apiURL string, apiKey string, apiVersion string) (*APIClient, 
 	return getAPIClient(apiURL, apiKey, apiVersion, nil)
 }
 
-func getAPIClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tls.Config) (*APIClient, error) {
+func getAPIClient(apiURL string, apiKey string, apiVersion string, tr *http.Transport) (*APIClient, error) {
 	versionedURL := gomaasapi.AddAPIVersionToURL(apiURL, apiVersion)
 
 	authClient, err := gomaasapi.NewAuthenticatedClient(versionedURL, apiKey)
@@ -174,11 +190,12 @@ func getAPIClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tl
 		return nil, err
 	}
 
-	if tlsConfig != nil {
-		tr := &http.Transport{TLSClientConfig: tlsConfig}
-		httpClient := &http.Client{Transport: tr}
-		authClient.HTTPClient = httpClient
+	if tr == nil {
+		tr = &http.Transport{}
 	}
+
+	httpClient := &http.Client{Transport: tr}
+	authClient.HTTPClient = httpClient
 
 	return &APIClient{*authClient, gomaasapi.NewMAAS(*authClient)}, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -3,15 +3,17 @@ package client
 
 import (
 	"crypto/tls"
-	gomaasapi "github.com/juju/gomaasapi/v2"
-	"github.com/maas/gomaasclient/api"
 	"net/http"
 	"net/url"
+
+	gomaasapi "github.com/juju/gomaasapi/v2"
+	"github.com/maas/gomaasclient/api"
 )
 
 // GetTLSClient creates a Client configured with TLS
 func GetTLSClient(apiURL string, apiKey string, apiVersion string, tlsConfig *tls.Config) (*Client, error) {
 	var tr http.RoundTripper
+
 	if tlsConfig != nil {
 		defaultTransportCopy := http.DefaultTransport.(*http.Transport).Clone()
 		defaultTransportCopy.TLSClientConfig = tlsConfig


### PR DESCRIPTION
This pull adds a new constructor function that takes in an `http.Transport`. This would allow users to pass in instrumented transports to support observability efforts and trace API requests to the MAAS backend.

I think a move towards a builder / option pattern would be more elegant here but I'm keeping my changes minimal. 

Fixes https://github.com/maas/gomaasclient/issues/32