### PR TITLE
fix: machines get should accept query params

### DIFF
--- a/api/machines.go
+++ b/api/machines.go
@@ -7,7 +7,7 @@ import (
 // Machines is an interface for listing, creating, allocating,
 // bulk-accepting enlistments and releasing Machine records
 type Machines interface {
-	Get() ([]entity.Machine, error)
+	Get(machinesParams *entity.MachinesParams) ([]entity.Machine, error)
 	Create(machineParams *entity.MachineParams, powerParams map[string]interface{}) (*entity.Machine, error)
 	Allocate(params *entity.MachineAllocateParams) (*entity.Machine, error)
 	AcceptAll() error

--- a/client/machines.go
+++ b/client/machines.go
@@ -18,9 +18,14 @@ func (m *Machines) client() APIClient {
 }
 
 // Get fetches a list machines.
-func (m *Machines) Get() ([]entity.Machine, error) {
+func (m *Machines) Get(machinesParams *entity.MachinesParams) ([]entity.Machine, error) {
+	qsp, err := query.Values(machinesParams)
+	if err != nil {
+		return nil, err
+	}
+
 	machines := make([]entity.Machine, 0)
-	err := m.client().Get("", url.Values{}, func(data []byte) error {
+	err = m.client().Get("", qsp, func(data []byte) error {
 		return json.Unmarshal(data, &machines)
 	})
 

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -305,6 +305,54 @@ type MachinePowerOffParams struct {
 	StopMode string `url:"stop_mode,omitempty"`
 }
 
+// MachinesParams enumerates the parameters for the get machines operation
+type MachinesParams struct {
+	ID               []string `url:"id,omitempty"`
+	NotID            []string `url:"not_id,omitempty"`
+	Hostname         []string `url:"hostname,omitempty"`
+	NotHostname      []string `url:"not_hostname,omitempty"`
+	MACAddress       []string `url:"mac_address,omitempty"`
+	Domain           []string `url:"domain,omitempty"`
+	NotDomain        []string `url:"not_domain,omitempty"`
+	AgentName        []string `url:"agent_name,omitempty"`
+	NotAgentName     []string `url:"not_agent_name,omitempty"`
+	Status           []string `url:"status,omitempty"`
+	NotStatus        []string `url:"not_status,omitempty"`
+	SimpleStatus     []string `url:"simple_status,omitempty"`
+	NotSimpleStatus  []string `url:"not_simple_status,omitempty"`
+	Arch             []string `url:"arch,omitempty"`
+	NotArch          []string `url:"not_arch,omitempty"`
+	Tags             []string `url:"tags,omitempty"`
+	NotTags          []string `url:"not_tags,omitempty"`
+	Fabrics          []string `url:"fabrics,omitempty"`
+	NotFabrics       []string `url:"not_fabrics,omitempty"`
+	FabricClasses    []string `url:"fabric_classes,omitempty"`
+	NotFabricClasses []string `url:"not_fabric_classes,omitempty"`
+	Subnets          []string `url:"subnets,omitempty"`
+	NotSubnets       []string `url:"not_subnets,omitempty"`
+	LinkSpeed        []int    `url:"link_speed,omitempty"`
+	VLANs            []string `url:"vlans,omitempty"`
+	NotVLANs         []string `url:"not_vlans,omitempty"`
+	Zone             []string `url:"zone,omitempty"`
+	NotInZone        []string `url:"not_in_zone,omitempty"`
+	Pool             []string `url:"pool,omitempty"`
+	NotInPool        []string `url:"not_in_pool,omitempty"`
+	Storage          string   `url:"storage,omitempty"`
+	Interfaces       string   `url:"devices,omitempty"`
+	Devices          string   `url:"devices,omitempty"`
+	CPUCount         []int    `url:"cpu_count,omitempty"`
+	CPUSpeed         []int    `url:"cpu_speed,omitempty"`
+	Mem              []int64  `url:"mem,omitempty"`
+	Pod              []string `url:"pod,omitempty"`
+	NotPod           []string `url:"not_pod,omitempty"`
+	PodType          []string `url:"pod_type,omitempty"`
+	NotPodType       []string `url:"not_pod_type,omitempty"`
+	Owner            []string `url:"owner,omitempty"`
+	NotOwner         []string `url:"not_owner,omitempty"`
+	PowerState       []string `url:"power_state,omitempty"`
+	NotPowerState    []string `url:"not_power_state,omitempty"`
+}
+
 type MachineDetails struct {
 	LLDP string `json:"lldp,omitempty"`
 	LSHW string `json:"lshw,omitempty"`


### PR DESCRIPTION
This PR contains all the filter options that can be set to MAAS v2 API to limit the machine list results.

The full list was gathered from source code:

- https://github.com/canonical/maas/blob/master/src/maasserver/api/machines.py#L1962
- https://github.com/canonical/maas/blob/master/src/maasserver/api/nodes.py#L807
- https://github.com/canonical/maas/blob/master/src/maasserver/node_constraint_filter_forms.py#L1356
- https://github.com/canonical/maas/blob/master/src/maasserver/node_constraint_filter_forms.py#L729

Fixes: #67 