### PR TITLE
feat: add machine method get-curtin-config

### DIFF
--- a/api/machine.go
+++ b/api/machine.go
@@ -30,5 +30,5 @@ type Machine interface {
 	RestoreDefaultConfiguration(systemID string) error
 	RestoreNetworkingConfiguration(systemID string) error
 	RestoreStorageConfiguration(systemID string) error
-  GetCurtinConfig(systemID string) (map[string]interface{}, error)
+	GetCurtinConfig(systemID string) (map[string]interface{}, error)
 }

--- a/api/machine.go
+++ b/api/machine.go
@@ -27,4 +27,5 @@ type Machine interface {
 	MarkFixed(systemID string, comment string) (*entity.Machine, error)
 	GetToken(systemID string) (*entity.MachineToken, error)
 	Details(systemID string) (*entity.MachineDetails, error)
+	GetCurtinConfig(systemID string) (map[string]interface{}, error)
 }

--- a/client/machine.go
+++ b/client/machine.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-querystring/query"
 	"github.com/maas/gomaasclient/entity"
 	"gopkg.in/mgo.v2/bson"
+	"gopkg.in/yaml.v3"
 )
 
 // Machine contains functionality for manipulating the Machine entity.
@@ -278,6 +279,7 @@ func (m *Machine) GetToken(systemID string) (*entity.MachineToken, error) {
 	return machineToken, err
 }
 
+// Details gets the details for a given machine
 func (m *Machine) Details(systemID string) (*entity.MachineDetails, error) {
 	machineDetails := new(entity.MachineDetails)
 	err := m.client(systemID).Get("details", url.Values{}, func(data []byte) error {
@@ -285,4 +287,14 @@ func (m *Machine) Details(systemID string) (*entity.MachineDetails, error) {
 	})
 
 	return machineDetails, err
+}
+
+// GetCurtinConfig gets the curtin config for a given machine
+func (m *Machine) GetCurtinConfig(systemID string) (map[string]interface{}, error) {
+	curtinConfig := map[string]interface{}{}
+	err := m.client(systemID).Get("get_curtin_config", url.Values{}, func(data []byte) error {
+		return yaml.Unmarshal(data, &curtinConfig)
+	})
+
+	return curtinConfig, err
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/juju/gomaasapi/v2 v2.2.0
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -19,5 +20,4 @@ require (
 	github.com/juju/schema v1.0.1 // indirect
 	github.com/juju/version v0.0.0-20210303051006-2015802527a8 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Add support for machine API call `op-get_curtin_config`. This endpoint returns the curtin config in YAML format.