### PR TITLE
feat: add machine restore configuration endpoints

### DIFF
--- a/api/machine.go
+++ b/api/machine.go
@@ -27,4 +27,7 @@ type Machine interface {
 	MarkFixed(systemID string, comment string) (*entity.Machine, error)
 	GetToken(systemID string) (*entity.MachineToken, error)
 	Details(systemID string) (*entity.MachineDetails, error)
+	RestoreDefaultConfiguration(systemID string) error
+	RestoreNetworkingConfiguration(systemID string) error
+	RestoreStorageConfiguration(systemID string) error
 }

--- a/client/machine.go
+++ b/client/machine.go
@@ -286,3 +286,18 @@ func (m *Machine) Details(systemID string) (*entity.MachineDetails, error) {
 
 	return machineDetails, err
 }
+
+// RestoreDefaultConfiguration sets the configuration to default values for a given machine
+func (m *Machine) RestoreDefaultConfiguration(systemID string) error {
+	return m.client(systemID).Post("restore_default_configuration", url.Values{}, func(data []byte) error { return nil })
+}
+
+// RestoreNetworkingConfiguration sets the network configuration to default values for a given machine
+func (m *Machine) RestoreNetworkingConfiguration(systemID string) error {
+	return m.client(systemID).Post("restore_networking_configuration", url.Values{}, func(data []byte) error { return nil })
+}
+
+// RestoreStorageConfiguration sets the storage configuration to default values for a given machine
+func (m *Machine) RestoreStorageConfiguration(systemID string) error {
+	return m.client(systemID).Post("restore_storage_configuration", url.Values{}, func(data []byte) error { return nil })
+}


### PR DESCRIPTION
This PR adds support for the following machine endpoints:

- restore_default_configuration
- restore_networking_configuration
- restore_storage_configuration