### PR TITLE
feat: support rack controllers

### DIFF
--- a/api/rack_controller.go
+++ b/api/rack_controller.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"github.com/maas/gomaasclient/entity"
+)
+
+// RackController represents the MAAS Rack Controller endpoint
+type RackController interface {
+	Get(systemID string) (*entity.RackController, error)
+	Update(systemID string, machineParams *entity.RackControllerParams, powerParams map[string]interface{}) (*entity.RackController, error)
+	Delete(systemID string) error
+	GetPowerParameters(systemID string) (map[string]interface{}, error)
+	PowerOn(systemID string, params *entity.RackControllerPowerOnParams) (*entity.RackController, error)
+	PowerOff(systemID string, params *entity.RackControllerPowerOffParams) (*entity.RackController, error)
+	GetPowerState(systemID string) (*entity.RackControllerPowerState, error)
+	Abort(systemID string, comment string) (*entity.RackController, error)
+	Details(systemID string) (*entity.RackControllerDetails, error)
+	OverrideFailedTesting(systemID string, comment string) (*entity.RackController, error)
+	Test(systemID string, params map[string]interface{}) (*entity.RackController, error)
+}

--- a/api/rack_controllers.go
+++ b/api/rack_controllers.go
@@ -6,5 +6,9 @@ import (
 
 // RackControllers represents the MAAS Rack Controllers endpoint
 type RackControllers interface {
-	Get(*entity.RackControllerSearch) ([]entity.RackController, error)
+	DescribePowerTypes() ([]entity.PowerType, error)
+	IsRegistered(macAddress string) (bool, error)
+	GetPowerParameters(systemIDs []string) (map[string]interface{}, error)
+	Get(*entity.RackControllersGetParams) ([]entity.RackController, error)
+	SetZone(*entity.RackControllerSetZoneParams) error
 }

--- a/client/client.go
+++ b/client/client.go
@@ -113,6 +113,8 @@ func constructClient(apiClient *APIClient) *Client {
 		SSLKeys:               &SSLKeys{APIClient: *apiClient},
 		Account:               &Account{APIClient: *apiClient},
 		Version:               &Version{APIClient: *apiClient},
+		RackController:        &RackController{APIClient: *apiClient},
+		RackControllers:       &RackControllers{APIClient: *apiClient},
 	}
 
 	return &client
@@ -183,6 +185,8 @@ type Client struct {
 	SSLKeys               api.SSLKeys
 	Account               api.Account
 	Version               api.Version
+	RackController        api.RackController
+	RackControllers       api.RackControllers
 }
 
 // GetAPIClient returns a MAAS API client.

--- a/client/rack_contoller.go
+++ b/client/rack_contoller.go
@@ -1,0 +1,159 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// RackController contains functionality for manipulating the RackController entity.
+type RackController struct {
+	APIClient APIClient
+}
+
+func (r *RackController) client(systemID string) APIClient {
+	return r.APIClient.GetSubObject("rackcontrollers").GetSubObject(systemID)
+}
+
+// Get rack controller details.
+func (r *RackController) Get(systemID string) (*entity.RackController, error) {
+	rackController := new(entity.RackController)
+	err := r.client(systemID).Get("", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}
+
+// Update rack controller.
+func (r *RackController) Update(systemID string, rackControllerParams *entity.RackControllerParams, powerParams map[string]interface{}) (*entity.RackController, error) {
+	qsp, err := query.Values(rackControllerParams)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range powerParamsToURLValues(powerParams) {
+		// Since qsp.Add(k, v...) is not allowed
+		qsp[k] = append(qsp[k], v...)
+	}
+
+	rackController := new(entity.RackController)
+	err = r.client(systemID).Put(qsp, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}
+
+// Delete rack controller.
+func (r *RackController) Delete(systemID string) error {
+	return r.client(systemID).Delete()
+}
+
+// GetPowerParameters fetches the power parameters of a given rack controller.
+func (r *RackController) GetPowerParameters(systemID string) (map[string]interface{}, error) {
+	params := map[string]interface{}{}
+	err := r.client(systemID).Get("power_parameters", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, &params)
+	})
+
+	return params, err
+}
+
+// PowerOn rack controller.
+func (r *RackController) PowerOn(systemID string, params *entity.RackControllerPowerOnParams) (*entity.RackController, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	rackController := new(entity.RackController)
+	err = r.client(systemID).Post("power_on", qsp, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}
+
+// PowerOff rack controller.
+func (r *RackController) PowerOff(systemID string, params *entity.RackControllerPowerOffParams) (*entity.RackController, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	rackController := new(entity.RackController)
+	err = r.client(systemID).Post("power_off", qsp, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}
+
+// GetPowerState of the rack controller.
+func (r *RackController) GetPowerState(systemID string) (*entity.RackControllerPowerState, error) {
+	ps := new(entity.RackControllerPowerState)
+	err := r.client(systemID).Get("query_power_state", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, ps)
+	})
+
+	return ps, err
+}
+
+// Abort rack controller current operation.
+func (r *RackController) Abort(systemID string, comment string) (*entity.RackController, error) {
+	qsp := make(url.Values)
+	if comment != "" {
+		qsp.Set("comment", comment)
+	}
+
+	rackController := new(entity.RackController)
+	err := r.client(systemID).Post("abort", qsp, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}
+
+// Details gets the details for a given rack controller.
+func (r *RackController) Details(systemID string) (*entity.RackControllerDetails, error) {
+	rackControllerDetails := new(entity.RackControllerDetails)
+	err := r.client(systemID).Get("details", url.Values{}, func(data []byte) error {
+		return bson.Unmarshal(data, rackControllerDetails)
+	})
+
+	return rackControllerDetails, err
+}
+
+// OverrideFailedTesting ignores failed tests of the rack controller.
+func (r *RackController) OverrideFailedTesting(systemID string, comment string) (*entity.RackController, error) {
+	qsp := make(url.Values)
+	if comment != "" {
+		qsp.Set("comment", comment)
+	}
+
+	rackController := new(entity.RackController)
+	err := r.client(systemID).Post("override_failed_testing", qsp, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}
+
+// Test the rack controller.
+func (r *RackController) Test(systemID string, params map[string]interface{}) (*entity.RackController, error) {
+	qsp, err := query.Values(params)
+	if err != nil {
+		return nil, err
+	}
+
+	rackController := new(entity.RackController)
+	err = r.client(systemID).Post("test", qsp, func(data []byte) error {
+		return json.Unmarshal(data, rackController)
+	})
+
+	return rackController, err
+}

--- a/client/rack_controllers.go
+++ b/client/rack_controllers.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/google/go-querystring/query"
+	"github.com/maas/gomaasclient/entity"
+)
+
+// RackControllers contains functionality for manipulating the RackControllers entity.
+type RackControllers struct {
+	APIClient APIClient
+}
+
+func (r *RackControllers) client() APIClient {
+	return r.APIClient.GetSubObject("rackControllers")
+}
+
+// Get fetches a list rackControllers.
+func (r *RackControllers) Get(rackControllersParams *entity.RackControllersGetParams) ([]entity.RackController, error) {
+	qsp, err := query.Values(rackControllersParams)
+	if err != nil {
+		return nil, err
+	}
+
+	rackControllers := make([]entity.RackController, 0)
+	err = r.client().Get("", qsp, func(data []byte) error {
+		return json.Unmarshal(data, &rackControllers)
+	})
+
+	return rackControllers, err
+}
+
+// DescribePowerTypes returns the supported power types of the rack controller.
+func (r *RackControllers) DescribePowerTypes() ([]entity.PowerType, error) {
+	powerTypes := make([]entity.PowerType, 0)
+	err := r.client().Get("describe_power_types", url.Values{}, func(data []byte) error {
+		return json.Unmarshal(data, &powerTypes)
+	})
+
+	return powerTypes, err
+}
+
+// IsRegistered confirms that a MAC Address is registered to MAAS.
+func (r *RackControllers) IsRegistered(macAddress string) (bool, error) {
+	qsp := url.Values{}
+	qsp.Set("mac_address", macAddress)
+
+	isRegistered := new(bool)
+	err := r.client().Get("is_registered", qsp, func(data []byte) error {
+		return json.Unmarshal(data, isRegistered)
+	})
+
+	return *isRegistered, err
+}
+
+// GetPowerParameters of a given node.
+func (r *RackControllers) GetPowerParameters(systemIDs []string) (map[string]interface{}, error) {
+	qsp, err := query.Values(map[string][]string{"id": systemIDs})
+	if err != nil {
+		return nil, err
+	}
+
+	params := map[string]interface{}{}
+	err = r.client().Get("power_parameters", qsp, func(data []byte) error {
+		return json.Unmarshal(data, &params)
+	})
+
+	return params, err
+}
+
+// SetZone to given nodes.
+func (r *RackControllers) SetZone(setZoneParams *entity.RackControllerSetZoneParams) error {
+	qsp, err := query.Values(setZoneParams)
+	if err != nil {
+		return err
+	}
+
+	err = r.client().Post("set_zone", qsp, func(data []byte) error { return nil })
+
+	return err
+}

--- a/entity/machine.go
+++ b/entity/machine.go
@@ -42,6 +42,9 @@ type Machine struct {
 	TestingStatusName       string                     `json:"testing_status_name,omitempty"`
 	Version                 string                     `json:"version,omitempty"`
 	BiosBootMethod          string                     `json:"bios_boot_method,omitempty"`
+	HardwareUUID            string                     `json:"hardware_uuid,omitempty"`
+	InterfaceTestStatusName string                     `json:"interface_test_status_name,omitempty"`
+	NetworkTestStatusName   string                     `json:"network_test_status_name,omitempty"`
 	Pool                    ResourcePool               `json:"pool,omitempty"`
 	Zone                    Zone                       `json:"zone,omitempty"`
 	SpecialFilesystems      []MachineSpecialFilesystem `json:"special_filesystems,omitempty"`
@@ -87,6 +90,8 @@ type Machine struct {
 	CommissioningStatus          int              `json:"commissioning_status,omitempty"`
 	OtherTestStatus              int              `json:"other_test_status,omitempty"`
 	TestingStatus                int              `json:"testing_status,omitempty"`
+	InterfaceTestStatus          int              `json:"interface_test_status,omitempty"`
+	NetworkTestStatus            int              `json:"network_test_status,omitempty"`
 	StorageTestStatus            int              `json:"storage_test_status,omitempty"`
 	SwapSize                     int64            `json:"swap_size,omitempty"`
 	MemoryTestStatus             int              `json:"memory_test_status,omitempty"`
@@ -195,9 +200,7 @@ type MachineServiceSet struct {
 }
 
 // MachinePowerState represent current machines power state
-type MachinePowerState struct {
-	State string `json:"state,omitempty"`
-}
+type MachinePowerState NodePowerState
 
 // MachineToken represents Machine token
 type MachineToken struct {
@@ -294,66 +297,13 @@ type MachineReleaseParams struct {
 
 // MachinePowerOnParams enumerates the parameters for the machine power on operation
 // UserData should be Base64-encoded data
-type MachinePowerOnParams struct {
-	Comment  string `url:"comment,omitempty"`
-	UserData string `url:"user_data,omitempty"`
-}
+type MachinePowerOnParams NodePowerOnParams
 
 // MachinePowerOffParams enumerates the parameters for the machine power off operation
-type MachinePowerOffParams struct {
-	Comment  string `url:"comment,omitempty"`
-	StopMode string `url:"stop_mode,omitempty"`
-}
+type MachinePowerOffParams NodePowerOffParams
 
 // MachinesParams enumerates the parameters for the get machines operation
-type MachinesParams struct {
-	ID               []string `url:"id,omitempty"`
-	NotID            []string `url:"not_id,omitempty"`
-	Hostname         []string `url:"hostname,omitempty"`
-	NotHostname      []string `url:"not_hostname,omitempty"`
-	MACAddress       []string `url:"mac_address,omitempty"`
-	Domain           []string `url:"domain,omitempty"`
-	NotDomain        []string `url:"not_domain,omitempty"`
-	AgentName        []string `url:"agent_name,omitempty"`
-	NotAgentName     []string `url:"not_agent_name,omitempty"`
-	Status           []string `url:"status,omitempty"`
-	NotStatus        []string `url:"not_status,omitempty"`
-	SimpleStatus     []string `url:"simple_status,omitempty"`
-	NotSimpleStatus  []string `url:"not_simple_status,omitempty"`
-	Arch             []string `url:"arch,omitempty"`
-	NotArch          []string `url:"not_arch,omitempty"`
-	Tags             []string `url:"tags,omitempty"`
-	NotTags          []string `url:"not_tags,omitempty"`
-	Fabrics          []string `url:"fabrics,omitempty"`
-	NotFabrics       []string `url:"not_fabrics,omitempty"`
-	FabricClasses    []string `url:"fabric_classes,omitempty"`
-	NotFabricClasses []string `url:"not_fabric_classes,omitempty"`
-	Subnets          []string `url:"subnets,omitempty"`
-	NotSubnets       []string `url:"not_subnets,omitempty"`
-	LinkSpeed        []int    `url:"link_speed,omitempty"`
-	VLANs            []string `url:"vlans,omitempty"`
-	NotVLANs         []string `url:"not_vlans,omitempty"`
-	Zone             []string `url:"zone,omitempty"`
-	NotInZone        []string `url:"not_in_zone,omitempty"`
-	Pool             []string `url:"pool,omitempty"`
-	NotInPool        []string `url:"not_in_pool,omitempty"`
-	Storage          string   `url:"storage,omitempty"`
-	Interfaces       string   `url:"devices,omitempty"`
-	Devices          string   `url:"devices,omitempty"`
-	CPUCount         []int    `url:"cpu_count,omitempty"`
-	CPUSpeed         []int    `url:"cpu_speed,omitempty"`
-	Mem              []int64  `url:"mem,omitempty"`
-	Pod              []string `url:"pod,omitempty"`
-	NotPod           []string `url:"not_pod,omitempty"`
-	PodType          []string `url:"pod_type,omitempty"`
-	NotPodType       []string `url:"not_pod_type,omitempty"`
-	Owner            []string `url:"owner,omitempty"`
-	NotOwner         []string `url:"not_owner,omitempty"`
-	PowerState       []string `url:"power_state,omitempty"`
-	NotPowerState    []string `url:"not_power_state,omitempty"`
-}
+type MachinesParams NodeGetParams
 
-type MachineDetails struct {
-	LLDP string `json:"lldp,omitempty"`
-	LSHW string `json:"lshw,omitempty"`
-}
+// MachineDetails represent the MAAS machine details
+type MachineDetails NodeDetails

--- a/entity/node.go
+++ b/entity/node.go
@@ -18,3 +18,75 @@ type NUMANodeHugepages struct {
 	PageSize int `json:"page_size,omitempty"`
 	Total    int `json:"total,omitempty"`
 }
+
+// NodeDetails represent the MAAS node details
+type NodeDetails struct {
+	LLDP string `json:"lldp,omitempty"`
+	LSHW string `json:"lshw,omitempty"`
+}
+
+// NodePowerState represent current node power state
+type NodePowerState struct {
+	State string `json:"state,omitempty"`
+}
+
+// NodeGetParams enumerates the parameters for the get nodes operation
+type NodeGetParams struct {
+	ID               []string `url:"id,omitempty"`
+	NotID            []string `url:"not_id,omitempty"`
+	Hostname         []string `url:"hostname,omitempty"`
+	NotHostname      []string `url:"not_hostname,omitempty"`
+	MACAddress       []string `url:"mac_address,omitempty"`
+	Domain           []string `url:"domain,omitempty"`
+	NotDomain        []string `url:"not_domain,omitempty"`
+	AgentName        []string `url:"agent_name,omitempty"`
+	NotAgentName     []string `url:"not_agent_name,omitempty"`
+	Status           []string `url:"status,omitempty"`
+	NotStatus        []string `url:"not_status,omitempty"`
+	SimpleStatus     []string `url:"simple_status,omitempty"`
+	NotSimpleStatus  []string `url:"not_simple_status,omitempty"`
+	Arch             []string `url:"arch,omitempty"`
+	NotArch          []string `url:"not_arch,omitempty"`
+	Tags             []string `url:"tags,omitempty"`
+	NotTags          []string `url:"not_tags,omitempty"`
+	Fabrics          []string `url:"fabrics,omitempty"`
+	NotFabrics       []string `url:"not_fabrics,omitempty"`
+	FabricClasses    []string `url:"fabric_classes,omitempty"`
+	NotFabricClasses []string `url:"not_fabric_classes,omitempty"`
+	Subnets          []string `url:"subnets,omitempty"`
+	NotSubnets       []string `url:"not_subnets,omitempty"`
+	LinkSpeed        []int    `url:"link_speed,omitempty"`
+	VLANs            []string `url:"vlans,omitempty"`
+	NotVLANs         []string `url:"not_vlans,omitempty"`
+	Zone             []string `url:"zone,omitempty"`
+	NotInZone        []string `url:"not_in_zone,omitempty"`
+	Pool             []string `url:"pool,omitempty"`
+	NotInPool        []string `url:"not_in_pool,omitempty"`
+	Storage          string   `url:"storage,omitempty"`
+	Interfaces       string   `url:"devices,omitempty"`
+	Devices          string   `url:"devices,omitempty"`
+	CPUCount         []int    `url:"cpu_count,omitempty"`
+	CPUSpeed         []int    `url:"cpu_speed,omitempty"`
+	Mem              []int64  `url:"mem,omitempty"`
+	Pod              []string `url:"pod,omitempty"`
+	NotPod           []string `url:"not_pod,omitempty"`
+	PodType          []string `url:"pod_type,omitempty"`
+	NotPodType       []string `url:"not_pod_type,omitempty"`
+	Owner            []string `url:"owner,omitempty"`
+	NotOwner         []string `url:"not_owner,omitempty"`
+	PowerState       []string `url:"power_state,omitempty"`
+	NotPowerState    []string `url:"not_power_state,omitempty"`
+}
+
+// NodePowerOnParams enumerates the parameters for the node power on operation
+// UserData should be Base64-encoded data
+type NodePowerOnParams struct {
+	Comment  string `url:"comment,omitempty"`
+	UserData string `url:"user_data,omitempty"`
+}
+
+// NodePowerOffParams enumerates the parameters for the node power off operation
+type NodePowerOffParams struct {
+	Comment  string `url:"comment,omitempty"`
+	StopMode string `url:"stop_mode,omitempty"`
+}

--- a/entity/rack_controller.go
+++ b/entity/rack_controller.go
@@ -1,16 +1,117 @@
 package entity
 
-// RackController represents the MAAS RackController endpoint.
-type RackController Machine
+import (
+	"net"
+)
 
-// RackControllerSearch narrows down the list in RackController.Get().
-// All fields are optional.
-type RackControllerSearch struct {
-	Hostname   string `json:"hostname,omitempty"`
-	MACAddress string `json:"mac_address,omitempty"`
-	SystemID   string `json:"id,omitempty"`
-	Domain     string `json:"domain,omitempty"`
-	Zone       string `json:"zone,omitempty"`
-	Pool       string `json:"pool,omitempty"`
-	AgentName  string `json:"agent_name,omitempty"`
+// RackController represents the MAAS Rack Controller endpoint.
+type RackController struct {
+	HardwareInfo                 map[string]string   `json:"hardware_info,omitempty"`
+	TestingStatusName            string              `json:"testing_status_name,omitempty"`
+	Architecture                 string              `json:"architecture,omitempty"`
+	Version                      string              `json:"version,omitempty"`
+	FQDN                         string              `json:"fqdn,omitempty"`
+	DistroSeries                 string              `json:"distro_series,omitempty"`
+	OSystem                      string              `json:"osystem,omitempty"`
+	StatusAction                 string              `json:"status_action,omitempty"`
+	SystemID                     string              `json:"system_id,omitempty"`
+	Description                  string              `json:"description,omitempty"`
+	PowerType                    string              `json:"power_type,omitempty"`
+	StorageTestStatusName        string              `json:"storage_test_status_name,omitempty"`
+	ResourceURI                  string              `json:"resource_uri,omitempty"`
+	PowerState                   string              `json:"power_state,omitempty"`
+	HardwareUUID                 string              `json:"hardware_uuid,omitempty"`
+	CommissioningStatusName      string              `json:"commissioning_status_name,omitempty"`
+	CPUTestStatusName            string              `json:"cpu_test_status_name,omitempty"`
+	InterfaceTestStatusName      string              `json:"interface_test_status_name,omitempty"`
+	MemoryTestStatusName         string              `json:"memory_test_status_name,omitempty"`
+	NetworkTestStatusName        string              `json:"network_test_status_name,omitempty"`
+	OtherTestStatusName          string              `json:"other_test_status_name,omitempty"`
+	NodeTypeName                 string              `json:"node_type_name,omitempty"`
+	Hostname                     string              `json:"hostname,omitempty"`
+	Zone                         Zone                `json:"zone,omitempty"`
+	InterfaceSet                 []NetworkInterface  `json:"interface_set,omitempty"`
+	IPAddresses                  []net.IP            `json:"ip_addresses,omitempty"`
+	ServiceSet                   []MachineServiceSet `json:"service_set,omitempty"`
+	TagNames                     []string            `json:"tag_names,omitempty"`
+	Domain                       Domain              `json:"domain,omitempty"`
+	TestingStatus                int                 `json:"testing_status,omitempty"`
+	CurrentTestingResultID       int                 `json:"current_testing_result_id,omitempty"`
+	CurrentCommissioningResultID int                 `json:"current_commissioning_result_id,omitempty"`
+	Memory                       int64               `json:"memory,omitempty"`
+	CPUCount                     int                 `json:"cpu_count,omitempty"`
+	NodeType                     int                 `json:"node_type,omitempty"`
+	CurrentInstallationResultID  int                 `json:"current_installation_result_id,omitempty"`
+	SwapSize                     int64               `json:"swap_size,omitempty"`
+	CommissioningStatus          int                 `json:"commissioning_status,omitempty"`
+	CPUTestStatus                int                 `json:"cpu_test_status,omitempty"`
+	InterfaceTestStatus          int                 `json:"interface_test_status,omitempty"`
+	MemoryTestStatus             int                 `json:"memory_test_status,omitempty"`
+	NetworkTestStatus            int                 `json:"network_test_status,omitempty"`
+	OtherTestStatus              int                 `json:"other_test_status,omitempty"`
+	StorageTestStatus            int                 `json:"storage_test_status,omitempty"`
+	CPUSpeed                     int                 `json:"cpu_speed,omitempty"`
 }
+
+// PowerType represents a Rack Controller's power type.
+type PowerType struct {
+	DriverType      string            `json:"driver_type,omitempty"`
+	Name            string            `json:"name,omitempty"`
+	Description     string            `json:"description,omitempty"`
+	Fields          []PowerTypeField  `json:"fields,omitempty"`
+	MissingPackages []string          `json:"missing_packages,omitempty"`
+	Chassis         bool              `json:"chassis,omitempty"`
+	CanProbe        bool              `json:"can_probe,omitempty"`
+	Queryable       bool              `json:"queryable,omitempty"`
+	Defaults        PowerTypeDefaults `json:"defaults,omitempty"`
+}
+
+// PowerTypeField represents a Rack Controller Power Type "field".
+// This type should not be used directly.
+type PowerTypeField struct {
+	Name      string     `json:"name,omitempty"`
+	Label     string     `json:"label,omitempty"`
+	FieldType string     `json:"field_type,omitempty"`
+	Default   string     `json:"default,omitempty"`
+	Scope     string     `json:"scope,omitempty"`
+	Choices   [][]string `json:"choices,omitempty"`
+	Required  bool       `json:"required,omitempty"`
+	Secret    bool       `json:"secret,omitempty"`
+}
+
+// PowerTypeDefaults represents a Rack Controller Power Type "defaults".
+// This type should not be used directly.
+type PowerTypeDefaults struct {
+	Cores   int   `json:"cores,omitempty"`
+	Memory  int64 `json:"memory,omitempty"`
+	Storage int64 `json:"storage,omitempty"`
+}
+
+// RackControllerDetails represent the MAAS rack controller details
+type RackControllerDetails NodeDetails
+
+// RackControllerPowerState represent current rack controller's power state
+type RackControllerPowerState NodePowerState
+
+// RackControllerSetZoneParams enumerates the parameters for the rack controller set_zone operation
+type RackControllerSetZoneParams struct {
+	Zone  string   `url:"zone,omitempty"`
+	Nodes []string `url:"nodes,omitempty"`
+}
+
+// RackControllersGetParams enumerates the parameters for the get rack controllers operation
+type RackControllersGetParams NodeGetParams
+
+// RackControllerParams enumerates the parameters for the update rack controller operation
+type RackControllerParams struct {
+	Zone      string `url:"zone,omitempty"`
+	Domain    string `url:"domain,omitempty"`
+	PowerType string `url:"power_type,omitempty"`
+}
+
+// RackControllerPowerOnParams enumerates the parameters for the rack controller power on operation
+// UserData should be Base64-encoded data
+type RackControllerPowerOnParams NodePowerOnParams
+
+// RackControllerPowerOffParams enumerates the parameters for the rack controller power off operation
+type RackControllerPowerOffParams NodePowerOffParams

--- a/entity/rack_controller_test.go
+++ b/entity/rack_controller_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/maas/gomaasclient/test/helper"
 )
 
-func TestRackControllert(t *testing.T) {
+func TestRackController(t *testing.T) {
 	rackController := new(RackController)
 	rackControllers := new([]RackController)
 

--- a/entity/subnet.go
+++ b/entity/subnet.go
@@ -6,19 +6,21 @@ import (
 
 // Subnet represents the MAAS Subnet endpoint.
 type Subnet struct {
-	Space           string   `json:"space,omitempty"`
-	CIDR            string   `json:"cidr,omitempty"`
-	Name            string   `json:"name,omitempty"`
-	ResourceURI     string   `json:"resource_uri,omitempty"`
-	DNSServers      []net.IP `json:"dns_servers,omitempty"`
-	GatewayIP       net.IP   `json:"gateway_ip,omitempty"`
-	VLAN            VLAN     `json:"vlan,omitempty"`
-	ID              int      `json:"id,omitempty"`
-	RDNSMode        int      `json:"rdns_mode,omitempty"`
-	AllowDNS        bool     `json:"allow_dns,omitempty"`
-	Managed         bool     `json:"managed,omitempty"`
-	ActiveDiscovery bool     `json:"active_discovery,omitempty"`
-	AllowProxy      bool     `json:"allow_proxy,omitempty"`
+	Space                     string   `json:"space,omitempty"`
+	CIDR                      string   `json:"cidr,omitempty"`
+	Name                      string   `json:"name,omitempty"`
+	ResourceURI               string   `json:"resource_uri,omitempty"`
+	Description               string   `json:"description,omitempty"`
+	GatewayIP                 net.IP   `json:"gateway_ip,omitempty"`
+	DNSServers                []net.IP `json:"dns_servers,omitempty"`
+	DisabledBootArchitectures []string `json:"disabled_boot_architectures,omitempty"`
+	VLAN                      VLAN     `json:"vlan,omitempty"`
+	ID                        int      `json:"id,omitempty"`
+	RDNSMode                  int      `json:"rdns_mode,omitempty"`
+	AllowDNS                  bool     `json:"allow_dns,omitempty"`
+	Managed                   bool     `json:"managed,omitempty"`
+	ActiveDiscovery           bool     `json:"active_discovery,omitempty"`
+	AllowProxy                bool     `json:"allow_proxy,omitempty"`
 }
 
 // SubnetParams contains the parameters for the POST operation on the Subnets endpoint.

--- a/test/testdata/maas/rack_controller.json
+++ b/test/testdata/maas/rack_controller.json
@@ -1,443 +1,405 @@
 {
-    "boot_interface": {
-        "system_id": "g8xyqs",
-        "name": "eth-jJ5ZwN",
-        "vlan": {
-            "vid": 0,
-            "mtu": 1500,
-            "dhcp_on": false,
-            "external_dhcp": null,
-            "relay_vlan": null,
-            "name": "untagged",
-            "fabric_id": 2,
-            "id": 5005,
-            "secondary_rack": null,
-            "space": "undefined",
-            "primary_rack": null,
-            "fabric": "fabric-2",
-            "resource_uri": "/MAAS/api/2.0/vlans/5005/"
-        },
-        "vendor": null,
-        "enabled": true,
-        "children": [
-            "bond-VpkNvO"
-        ],
-        "discovered": [],
-        "id": 112,
-        "params": "",
-        "type": "physical",
-        "firmware_version": null,
-        "mac_address": "3d:fd:40:ef:70:e8",
-        "parents": [],
-        "tags": [
-            "tag-M21kgB",
-            "tag-CpnGzQ",
-            "tag-Wgd7Eu"
-        ],
-        "links": [],
-        "effective_mtu": 1500,
-        "product": null,
-        "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/interfaces/112/"
-    },
-    "memory": 8192,
-    "tag_names": [],
-    "current_installation_result_id": null,
-    "fqdn": "causal-quagga.maas",
-    "disable_ipv4": false,
-    "distro_series": "",
-    "ip_addresses": [],
-    "pool": {
-        "name": "default",
-        "description": "Default pool",
-        "id": 0,
-        "resource_uri": "/MAAS/api/2.0/resourcepool/0/"
-    },
-    "node_type": 0,
-    "min_hwe_kernel": null,
-    "commissioning_status_name": "Passed",
+    "fqdn": "maas-dev.maas",
+    "cpu_test_status": -1,
     "domain": {
         "authoritative": true,
         "ttl": null,
-        "name": "maas",
-        "resource_record_count": 0,
         "id": 0,
         "is_default": true,
+        "name": "maas",
+        "resource_record_count": 0,
         "resource_uri": "/MAAS/api/2.0/domains/0/"
     },
-    "boot_disk": {
-        "firmware_version": "firmware_version-tnhqNO",
-        "partitions": [],
-        "system_id": "g8xyqs",
-        "name": "name-rcEM1G",
-        "id_path": null,
-        "block_size": 512,
-        "model": "model-RAViIE",
-        "available_size": 2250362368,
-        "id": 75,
-        "filesystem": null,
-        "size": 2250362368,
-        "type": "physical",
-        "used_size": 0,
-        "partition_table_type": null,
-        "serial": "serial-qlOilQ",
-        "path": "/dev/disk/by-dname/name-rcEM1G",
-        "tags": [
-            "tag-OKbSzN",
-            "tag-IExJAF",
-            "tag-p2t26t"
-        ],
-        "storage_pool": "pool_id-ry2OnY",
-        "uuid": null,
-        "used_for": "Unused",
-        "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/75/"
-    },
-    "system_id": "g8xyqs",
-    "zone": {
-        "name": "zone-north",
-        "description": "xsMaq90fRE",
-        "id": 2,
-        "resource_uri": "/MAAS/api/2.0/zones/zone-north/"
-    },
-    "blockdevice_set": [
-        {
-            "id_path": null,
-            "size": 2250362368,
-            "block_size": 512,
-            "tags": [
-                "tag-OKbSzN",
-                "tag-IExJAF",
-                "tag-p2t26t"
-            ],
-            "partitions": [],
-            "system_id": "g8xyqs",
-            "name": "name-rcEM1G",
-            "model": "model-RAViIE",
-            "available_size": 2250362368,
-            "id": 75,
-            "filesystem": null,
-            "type": "physical",
-            "used_size": 0,
-            "partition_table_type": null,
-            "serial": "serial-qlOilQ",
-            "path": "/dev/disk/by-dname/name-rcEM1G",
-            "storage_pool": "pool_id-ry2OnY",
-            "uuid": null,
-            "used_for": "Unused",
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/75/"
-        },
-        {
-            "id_path": null,
-            "size": 1443074048,
-            "block_size": 4096,
-            "tags": [
-                "tag-sgRDAF",
-                "tag-kytOd1",
-                "tag-acWXTG"
-            ],
-            "partitions": [],
-            "system_id": "g8xyqs",
-            "name": "name-a5uEVy",
-            "model": "model-0mBTZN",
-            "available_size": 1443074048,
-            "id": 76,
-            "filesystem": null,
-            "type": "physical",
-            "used_size": 0,
-            "partition_table_type": null,
-            "serial": "serial-fbDnkc",
-            "path": "/dev/disk/by-dname/name-a5uEVy",
-            "storage_pool": "pool_id-aMRZUu",
-            "uuid": null,
-            "used_for": "Unused",
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/76/"
-        }
-    ],
-    "current_commissioning_result_id": 198,
-    "cpu_test_status": 2,
-    "address_ttl": null,
-    "cache_sets": [],
-    "storage": 3693.436416,
-    "node_type_name": "Machine",
+    "current_installation_result_id": null,
     "hardware_info": {
         "system_vendor": "Unknown",
         "system_product": "Unknown",
+        "system_family": "Unknown",
         "system_version": "Unknown",
+        "system_sku": "Unknown",
         "system_serial": "Unknown",
         "cpu_model": "Unknown",
         "mainboard_vendor": "Unknown",
         "mainboard_product": "Unknown",
+        "mainboard_serial": "Unknown",
+        "mainboard_version": "Unknown",
+        "mainboard_firmware_vendor": "Unknown",
+        "mainboard_firmware_date": "Unknown",
         "mainboard_firmware_version": "Unknown",
-        "mainboard_firmware_date": "Unknown"
+        "chassis_vendor": "Unknown",
+        "chassis_type": "Unknown",
+        "chassis_serial": "Unknown",
+        "chassis_version": "Unknown"
     },
-    "cpu_count": 7,
-    "storage_test_status_name": "Passed",
-    "owner": "user2",
-    "status": 20,
-    "volume_groups": [],
-    "hwe_kernel": null,
-    "netboot": true,
-    "current_testing_result_id": 199,
+    "interface_test_status": -1,
+    "ip_addresses": [
+        "10.10.0.28",
+        "10.20.0.2",
+        "10.38.222.1"
+    ],
+    "version": "3.5.0~beta1-16455-g.fba1efbdd2",
+    "architecture": "amd64/generic",
+    "network_test_status": -1,
+    "other_test_status": -1,
+    "network_test_status_name": "Unknown",
+    "zone": {
+        "name": "default",
+        "description": "",
+        "id": 1,
+        "resource_uri": "/MAAS/api/2.0/zones/default/"
+    },
+    "other_test_status_name": "Unknown",
+    "distro_series": "jammy",
+    "osystem": "ubuntu",
+    "memory": 32640,
+    "power_state": "unknown",
     "commissioning_status": 2,
-    "testing_status_name": "Passed",
-    "architecture": "i386/generic",
-    "locked": false,
-    "power_state": "error",
-    "memory_test_status_name": "Passed",
-    "power_type": "virsh",
+    "hardware_uuid": null,
+    "testing_status_name": "Unknown",
+    "testing_status": -1,
+    "current_testing_result_id": null,
+    "node_type": 4,
     "interface_set": [
         {
-            "system_id": "g8xyqs",
-            "name": "eth-jJ5ZwN",
-            "vlan": {
-                "vid": 0,
-                "mtu": 1500,
-                "dhcp_on": false,
-                "external_dhcp": null,
-                "relay_vlan": null,
-                "name": "untagged",
-                "fabric_id": 2,
-                "id": 5005,
-                "secondary_rack": null,
-                "space": "undefined",
-                "primary_rack": null,
-                "fabric": "fabric-2",
-                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
-            },
-            "vendor": null,
-            "enabled": true,
-            "children": [
-                "bond-VpkNvO"
-            ],
-            "discovered": [],
-            "id": 112,
-            "params": "",
-            "type": "physical",
+            "name": "eth0",
             "firmware_version": null,
-            "mac_address": "3d:fd:40:ef:70:e8",
-            "parents": [],
-            "tags": [
-                "tag-M21kgB",
-                "tag-CpnGzQ",
-                "tag-Wgd7Eu"
-            ],
-            "links": [],
-            "effective_mtu": 1500,
-            "product": null,
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/interfaces/112/"
-        },
-        {
-            "system_id": "g8xyqs",
-            "name": "eth-ex07mq",
+            "params": {},
+            "link_connected": true,
             "vlan": {
                 "vid": 0,
                 "mtu": 1500,
                 "dhcp_on": false,
                 "external_dhcp": null,
                 "relay_vlan": null,
+                "primary_rack": null,
+                "fabric_id": 0,
+                "id": 1,
+                "fabric": "fabric-0",
                 "name": "untagged",
-                "fabric_id": 2,
-                "id": 5005,
                 "secondary_rack": null,
                 "space": "undefined",
-                "primary_rack": null,
-                "fabric": "fabric-2",
-                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
+                "resource_uri": "/MAAS/api/2.0/vlans/1/"
             },
-            "vendor": null,
             "enabled": true,
-            "children": [
-                "bond-VpkNvO"
-            ],
-            "discovered": [],
-            "id": 113,
-            "params": "",
-            "type": "physical",
-            "firmware_version": null,
-            "mac_address": "8f:75:69:58:26:47",
-            "parents": [],
-            "tags": [
-                "tag-ymen6c",
-                "tag-oKQ7iK",
-                "tag-yQLBgJ"
-            ],
-            "links": [],
-            "effective_mtu": 1500,
-            "product": null,
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/interfaces/113/"
-        },
-        {
-            "system_id": "g8xyqs",
-            "name": "eth-CE1j2X",
-            "vlan": {
-                "vid": 0,
-                "mtu": 1500,
-                "dhcp_on": false,
-                "external_dhcp": null,
-                "relay_vlan": null,
-                "name": "untagged",
-                "fabric_id": 2,
-                "id": 5005,
-                "secondary_rack": null,
-                "space": "undefined",
-                "primary_rack": null,
-                "fabric": "fabric-2",
-                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
-            },
-            "vendor": null,
-            "enabled": true,
-            "children": [
-                "bond-VpkNvO"
-            ],
-            "discovered": [],
-            "id": 114,
-            "params": "",
-            "type": "physical",
-            "firmware_version": null,
-            "mac_address": "b0:5e:ed:8d:d8:36",
-            "parents": [],
-            "tags": [
-                "tag-LJPUwT",
-                "tag-U5zGn3",
-                "tag-dHGEeD"
-            ],
-            "links": [],
-            "effective_mtu": 1500,
-            "product": null,
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/interfaces/114/"
-        },
-        {
-            "system_id": "g8xyqs",
-            "name": "bond-VpkNvO",
-            "vlan": {
-                "vid": 0,
-                "mtu": 1500,
-                "dhcp_on": false,
-                "external_dhcp": null,
-                "relay_vlan": null,
-                "name": "untagged",
-                "fabric_id": 2,
-                "id": 5005,
-                "secondary_rack": null,
-                "space": "undefined",
-                "primary_rack": null,
-                "fabric": "fabric-2",
-                "resource_uri": "/MAAS/api/2.0/vlans/5005/"
-            },
-            "vendor": null,
-            "enabled": true,
+            "interface_speed": 0,
             "children": [],
-            "discovered": [],
-            "id": 115,
-            "params": "",
-            "type": "bond",
-            "firmware_version": null,
-            "mac_address": "0a:87:3f:94:0e:68",
-            "parents": [
-                "eth-CE1j2X",
-                "eth-ex07mq",
-                "eth-jJ5ZwN"
-            ],
-            "tags": [
-                "tag-HwhC7n",
-                "tag-WHGBJc",
-                "tag-yY8Ap5"
-            ],
-            "links": [],
-            "effective_mtu": 1500,
+            "id": 1,
+            "system_id": "m6w3b4",
             "product": null,
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/interfaces/115/"
-        }
-    ],
-    "owner_data": {},
-    "bcaches": [],
-    "hostname": "causal-quagga",
-    "description": "Optional description for the node.",
-    "raids": [],
-    "other_test_status": 2,
-    "status_action": "action-BqENyW",
-    "special_filesystems": [],
-    "physicalblockdevice_set": [
-        {
-            "firmware_version": "firmware_version-tnhqNO",
-            "partitions": [],
-            "system_id": "g8xyqs",
-            "name": "name-rcEM1G",
-            "id_path": null,
-            "block_size": 512,
-            "model": "model-RAViIE",
-            "available_size": 2250362368,
-            "id": 75,
-            "filesystem": null,
-            "size": 2250362368,
-            "type": "physical",
-            "used_size": 0,
-            "partition_table_type": null,
-            "serial": "serial-qlOilQ",
-            "path": "/dev/disk/by-dname/name-rcEM1G",
-            "tags": [
-                "tag-OKbSzN",
-                "tag-IExJAF",
-                "tag-p2t26t"
+            "effective_mtu": 1500,
+            "discovered": null,
+            "numa_node": 0,
+            "mac_address": "00:16:3e:43:cd:7e",
+            "tags": [],
+            "links": [
+                {
+                    "id": 1,
+                    "mode": "static",
+                    "ip_address": "10.10.0.28",
+                    "subnet": {
+                        "name": "10.10.0.0/24",
+                        "description": "",
+                        "vlan": {
+                            "vid": 0,
+                            "mtu": 1500,
+                            "dhcp_on": false,
+                            "external_dhcp": null,
+                            "relay_vlan": null,
+                            "primary_rack": null,
+                            "fabric_id": 0,
+                            "id": 1,
+                            "fabric": "fabric-0",
+                            "name": "untagged",
+                            "secondary_rack": null,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/vlans/1/"
+                        },
+                        "cidr": "10.10.0.0/24",
+                        "rdns_mode": 2,
+                        "gateway_ip": "10.10.0.1",
+                        "dns_servers": [],
+                        "allow_dns": true,
+                        "allow_proxy": true,
+                        "active_discovery": false,
+                        "managed": true,
+                        "disabled_boot_architectures": [],
+                        "id": 1,
+                        "space": "undefined",
+                        "resource_uri": "/MAAS/api/2.0/subnets/1/"
+                    }
+                }
             ],
-            "storage_pool": "pool_id-ry2OnY",
-            "uuid": null,
-            "used_for": "Unused",
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/75/"
+            "link_speed": 0,
+            "vendor": null,
+            "sriov_max_vf": 0,
+            "parents": [],
+            "type": "physical",
+            "resource_uri": "/MAAS/api/2.0/nodes/m6w3b4/interfaces/1/"
         },
         {
-            "firmware_version": "firmware_version-UW8ucD",
-            "partitions": [],
-            "system_id": "g8xyqs",
-            "name": "name-a5uEVy",
-            "id_path": null,
-            "block_size": 4096,
-            "model": "model-0mBTZN",
-            "available_size": 1443074048,
-            "id": 76,
-            "filesystem": null,
-            "size": 1443074048,
-            "type": "physical",
-            "used_size": 0,
-            "partition_table_type": null,
-            "serial": "serial-fbDnkc",
-            "path": "/dev/disk/by-dname/name-a5uEVy",
-            "tags": [
-                "tag-sgRDAF",
-                "tag-kytOd1",
-                "tag-acWXTG"
+            "name": "eth1",
+            "firmware_version": null,
+            "params": {},
+            "link_connected": true,
+            "vlan": {
+                "vid": 0,
+                "mtu": 1500,
+                "dhcp_on": true,
+                "external_dhcp": null,
+                "relay_vlan": null,
+                "primary_rack": "m6w3b4",
+                "fabric_id": 1,
+                "id": 2,
+                "fabric": "fabric-1",
+                "name": "untagged",
+                "secondary_rack": null,
+                "space": "undefined",
+                "resource_uri": "/MAAS/api/2.0/vlans/2/"
+            },
+            "enabled": true,
+            "interface_speed": 0,
+            "children": [],
+            "id": 2,
+            "system_id": "m6w3b4",
+            "product": null,
+            "effective_mtu": 1500,
+            "discovered": null,
+            "numa_node": 0,
+            "mac_address": "00:16:3e:6d:ff:2f",
+            "tags": [],
+            "links": [
+                {
+                    "id": 2,
+                    "mode": "static",
+                    "ip_address": "10.20.0.2",
+                    "subnet": {
+                        "name": "10.20.0.0/24",
+                        "description": "",
+                        "vlan": {
+                            "vid": 0,
+                            "mtu": 1500,
+                            "dhcp_on": true,
+                            "external_dhcp": null,
+                            "relay_vlan": null,
+                            "primary_rack": "m6w3b4",
+                            "fabric_id": 1,
+                            "id": 2,
+                            "fabric": "fabric-1",
+                            "name": "untagged",
+                            "secondary_rack": null,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/vlans/2/"
+                        },
+                        "cidr": "10.20.0.0/24",
+                        "rdns_mode": 2,
+                        "gateway_ip": "10.20.0.1",
+                        "dns_servers": [],
+                        "allow_dns": true,
+                        "allow_proxy": true,
+                        "active_discovery": false,
+                        "managed": true,
+                        "disabled_boot_architectures": [],
+                        "id": 2,
+                        "space": "undefined",
+                        "resource_uri": "/MAAS/api/2.0/subnets/2/"
+                    }
+                }
             ],
-            "storage_pool": "pool_id-aMRZUu",
-            "uuid": null,
-            "used_for": "Unused",
-            "resource_uri": "/MAAS/api/2.0/nodes/g8xyqs/blockdevices/76/"
+            "link_speed": 0,
+            "vendor": null,
+            "sriov_max_vf": 0,
+            "parents": [],
+            "type": "physical",
+            "resource_uri": "/MAAS/api/2.0/nodes/m6w3b4/interfaces/2/"
+        },
+        {
+            "name": "mpqemubr0",
+            "firmware_version": null,
+            "params": {},
+            "link_connected": true,
+            "vlan": {
+                "vid": 0,
+                "mtu": 1500,
+                "dhcp_on": false,
+                "external_dhcp": null,
+                "relay_vlan": null,
+                "primary_rack": null,
+                "fabric_id": 7,
+                "id": 19,
+                "fabric": "fabric-7",
+                "name": "untagged",
+                "secondary_rack": null,
+                "space": "undefined",
+                "resource_uri": "/MAAS/api/2.0/vlans/19/"
+            },
+            "enabled": true,
+            "interface_speed": 0,
+            "children": [],
+            "id": 154,
+            "system_id": "m6w3b4",
+            "product": null,
+            "effective_mtu": 1500,
+            "discovered": null,
+            "numa_node": null,
+            "mac_address": "52:54:00:40:e3:c5",
+            "tags": [],
+            "links": [
+                {
+                    "id": 191,
+                    "mode": "static",
+                    "ip_address": "10.38.222.1",
+                    "subnet": {
+                        "name": "10.38.222.0/24",
+                        "description": "",
+                        "vlan": {
+                            "vid": 0,
+                            "mtu": 1500,
+                            "dhcp_on": false,
+                            "external_dhcp": null,
+                            "relay_vlan": null,
+                            "primary_rack": null,
+                            "fabric_id": 7,
+                            "id": 19,
+                            "fabric": "fabric-7",
+                            "name": "untagged",
+                            "secondary_rack": null,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/vlans/19/"
+                        },
+                        "cidr": "10.38.222.0/24",
+                        "rdns_mode": 2,
+                        "gateway_ip": null,
+                        "dns_servers": [],
+                        "allow_dns": true,
+                        "allow_proxy": true,
+                        "active_discovery": false,
+                        "managed": true,
+                        "disabled_boot_architectures": [],
+                        "id": 12,
+                        "space": "undefined",
+                        "resource_uri": "/MAAS/api/2.0/subnets/12/"
+                    }
+                }
+            ],
+            "link_speed": 0,
+            "vendor": null,
+            "sriov_max_vf": 0,
+            "parents": [],
+            "type": "bridge",
+            "resource_uri": "/MAAS/api/2.0/nodes/m6w3b4/interfaces/154/"
         }
     ],
-    "iscsiblockdevice_set": [],
-    "testing_status": 2,
-    "default_gateways": {
-        "ipv4": {
-            "gateway_ip": null,
-            "link_id": null
+    "hostname": "maas-dev",
+    "service_set": [
+        {
+            "name": "proxy",
+            "status": "running",
+            "status_info": ""
         },
-        "ipv6": {
-            "gateway_ip": null,
-            "link_id": null
+        {
+            "name": "regiond",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "ntp_region",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "temporal-worker",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "temporal",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "syslog_region",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "bind9",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "reverse_proxy",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "agent",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "dhcpd6",
+            "status": "off",
+            "status_info": ""
+        },
+        {
+            "name": "http",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "dhcpd",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "rackd",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "dns_rack",
+            "status": "unknown",
+            "status_info": "managed by the region"
+        },
+        {
+            "name": "tftp",
+            "status": "running",
+            "status_info": ""
+        },
+        {
+            "name": "syslog_rack",
+            "status": "unknown",
+            "status_info": "managed by the region"
+        },
+        {
+            "name": "proxy_rack",
+            "status": "unknown",
+            "status_info": "managed by the region"
+        },
+        {
+            "name": "ntp_rack",
+            "status": "unknown",
+            "status_info": "managed by the region"
         }
-    },
-    "storage_test_status": 2,
-    "pod": {
-        "id": 5,
-        "name": "sacred-hen",
-        "resource_uri": "/MAAS/api/2.0/pods/5/"
-    },
+    ],
+    "cpu_count": 12,
+    "status_action": "",
+    "storage_test_status_name": "Unknown",
+    "storage_test_status": -1,
+    "system_id": "m6w3b4",
+    "memory_test_status_name": "Unknown",
+    "description": "Test description",
+    "cpu_speed": 5000,
     "swap_size": null,
-    "status_message": "desc-eqGqfo",
-    "status_name": "Failed to exit rescue mode",
-    "osystem": "",
-    "cpu_test_status_name": "Passed",
-    "memory_test_status": 2,
-    "other_test_status_name": "Passed",
-    "virtualblockdevice_set": [],
-    "cpu_speed": 0,
-    "resource_uri": "/MAAS/api/2.0/machines/g8xyqs/"
+    "power_type": "",
+    "interface_test_status_name": "Unknown",
+    "node_type_name": "Region and rack controller",
+    "memory_test_status": -1,
+    "commissioning_status_name": "Passed",
+    "cpu_test_status_name": "Unknown",
+    "current_commissioning_result_id": 1,
+    "tag_names": [
+        "virtual"
+    ],
+    "resource_uri": "/MAAS/api/2.0/rackcontrollers/m6w3b4/"
 }

--- a/test/testdata/maas/rack_controllers.json
+++ b/test/testdata/maas/rack_controllers.json
@@ -1,44 +1,15 @@
 [
     {
-        "commissioning_status": 2,
-        "version": "2.5.0~beta3-7325-g1425f6d4c-0ubuntu1~18.04.1",
-        "node_type_name": "Region and rack controller",
-        "ip_addresses": [
-            "10.55.32.135",
-            "192.168.122.1"
-        ],
         "storage_test_status": -1,
-        "cpu_count": 4,
-        "hostname": "mymaas",
-        "description": "Optional description for the node.",
-        "domain": {
-            "authoritative": true,
-            "ttl": null,
-            "id": 0,
-            "name": "maas",
-            "resource_record_count": 23,
-            "is_default": true,
-            "resource_uri": "/MAAS/api/2.0/domains/0/"
-        },
-        "swap_size": null,
-        "power_type": "",
-        "memory": 8192,
-        "current_testing_result_id": null,
-        "osystem": "ubuntu",
-        "node_type": 4,
+        "system_id": "m6w3b4",
+        "other_test_status": -1,
+        "storage_test_status_name": "Unknown",
+        "current_commissioning_result_id": 1,
+        "interface_test_status_name": "Unknown",
+        "distro_series": "jammy",
         "service_set": [
             {
                 "name": "proxy",
-                "status": "running",
-                "status_info": ""
-            },
-            {
-                "name": "bind9",
-                "status": "running",
-                "status_info": ""
-            },
-            {
-                "name": "ntp_region",
                 "status": "running",
                 "status_info": ""
             },
@@ -48,14 +19,49 @@
                 "status_info": ""
             },
             {
+                "name": "ntp_region",
+                "status": "running",
+                "status_info": ""
+            },
+            {
+                "name": "temporal-worker",
+                "status": "running",
+                "status_info": ""
+            },
+            {
+                "name": "temporal",
+                "status": "running",
+                "status_info": ""
+            },
+            {
                 "name": "syslog_region",
                 "status": "running",
                 "status_info": ""
             },
             {
-                "name": "ntp_rack",
-                "status": "unknown",
-                "status_info": "managed by the region"
+                "name": "bind9",
+                "status": "running",
+                "status_info": ""
+            },
+            {
+                "name": "reverse_proxy",
+                "status": "running",
+                "status_info": ""
+            },
+            {
+                "name": "agent",
+                "status": "running",
+                "status_info": ""
+            },
+            {
+                "name": "dhcpd6",
+                "status": "off",
+                "status_info": ""
+            },
+            {
+                "name": "http",
+                "status": "running",
+                "status_info": ""
             },
             {
                 "name": "dhcpd",
@@ -63,7 +69,7 @@
                 "status_info": ""
             },
             {
-                "name": "tftp",
+                "name": "rackd",
                 "status": "running",
                 "status_info": ""
             },
@@ -73,14 +79,9 @@
                 "status_info": "managed by the region"
             },
             {
-                "name": "http",
+                "name": "tftp",
                 "status": "running",
                 "status_info": ""
-            },
-            {
-                "name": "proxy_rack",
-                "status": "unknown",
-                "status_info": "managed by the region"
             },
             {
                 "name": "syslog_rack",
@@ -88,150 +89,271 @@
                 "status_info": "managed by the region"
             },
             {
-                "name": "dhcpd6",
-                "status": "off",
-                "status_info": ""
+                "name": "proxy_rack",
+                "status": "unknown",
+                "status_info": "managed by the region"
             },
             {
-                "name": "rackd",
-                "status": "running",
-                "status_info": ""
+                "name": "ntp_rack",
+                "status": "unknown",
+                "status_info": "managed by the region"
             }
         ],
-        "other_test_status": -1,
-        "testing_status": -1,
+        "current_testing_result_id": null,
+        "memory": 32640,
+        "description": "Test description",
+        "node_type": 4,
+        "commissioning_status": 2,
+        "commissioning_status_name": "Passed",
+        "cpu_count": 12,
+        "power_type": "",
+        "tag_names": [
+            "virtual"
+        ],
+        "node_type_name": "Region and rack controller",
+        "cpu_test_status_name": "Unknown",
         "zone": {
             "name": "default",
             "description": "",
             "id": 1,
             "resource_uri": "/MAAS/api/2.0/zones/default/"
         },
+        "ip_addresses": [
+            "10.10.0.28",
+            "10.20.0.2",
+            "10.38.222.1"
+        ],
+        "memory_test_status": -1,
+        "network_test_status_name": "Unknown",
+        "version": "3.5.0~beta1-16455-g.fba1efbdd2",
         "status_action": "",
-        "commissioning_status_name": "Passed",
+        "cpu_test_status": -1,
+        "architecture": "amd64/generic",
+        "hardware_info": {
+            "system_vendor": "Unknown",
+            "system_product": "Unknown",
+            "system_family": "Unknown",
+            "system_version": "Unknown",
+            "system_sku": "Unknown",
+            "system_serial": "Unknown",
+            "cpu_model": "Unknown",
+            "mainboard_vendor": "Unknown",
+            "mainboard_product": "Unknown",
+            "mainboard_serial": "Unknown",
+            "mainboard_version": "Unknown",
+            "mainboard_firmware_vendor": "Unknown",
+            "mainboard_firmware_date": "Unknown",
+            "mainboard_firmware_version": "Unknown",
+            "chassis_vendor": "Unknown",
+            "chassis_type": "Unknown",
+            "chassis_serial": "Unknown",
+            "chassis_version": "Unknown"
+        },
+        "memory_test_status_name": "Unknown",
+        "hostname": "maas-dev",
+        "swap_size": null,
+        "fqdn": "maas-dev.maas",
+        "osystem": "ubuntu",
+        "testing_status_name": "Unknown",
+        "hardware_uuid": null,
+        "network_test_status": -1,
+        "other_test_status_name": "Unknown",
+        "interface_test_status": -1,
+        "domain": {
+            "authoritative": true,
+            "ttl": null,
+            "resource_record_count": 0,
+            "is_default": true,
+            "id": 0,
+            "name": "maas",
+            "resource_uri": "/MAAS/api/2.0/domains/0/"
+        },
+        "power_state": "unknown",
         "interface_set": [
             {
-                "vlan": {
-                    "vid": 0,
-                    "mtu": 1500,
-                    "dhcp_on": true,
-                    "external_dhcp": null,
-                    "relay_vlan": null,
-                    "id": 5001,
-                    "name": "untagged",
-                    "fabric_id": 0,
-                    "secondary_rack": null,
-                    "space": "undefined",
-                    "fabric": "fabric-0",
-                    "primary_rack": "6gsym8",
-                    "resource_uri": "/MAAS/api/2.0/vlans/5001/"
-                },
-                "mac_address": "fa:16:3e:b8:af:ff",
-                "tags": [],
-                "params": "",
-                "id": 1,
-                "discovered": [],
-                "product": "OpenStack Nova",
-                "parents": [],
-                "type": "physical",
-                "name": "ens3",
+                "system_id": "m6w3b4",
                 "enabled": true,
-                "effective_mtu": 1500,
-                "vendor": "OpenStack Foundation",
-                "system_id": "6gsym8",
                 "children": [],
-                "firmware_version": null,
+                "numa_node": 0,
+                "mac_address": "00:16:3e:43:cd:7e",
+                "product": null,
+                "effective_mtu": 1500,
                 "links": [
                     {
                         "id": 1,
                         "mode": "static",
-                        "ip_address": "10.55.32.135",
+                        "ip_address": "10.10.0.28",
                         "subnet": {
-                            "name": "10.55.32.0/20",
-                            "vlan": {
-                                "vid": 0,
-                                "mtu": 1500,
-                                "dhcp_on": true,
-                                "external_dhcp": null,
-                                "relay_vlan": null,
-                                "id": 5001,
-                                "name": "untagged",
-                                "fabric_id": 0,
-                                "secondary_rack": null,
-                                "space": "undefined",
-                                "fabric": "fabric-0",
-                                "primary_rack": "6gsym8",
-                                "resource_uri": "/MAAS/api/2.0/vlans/5001/"
-                            },
-                            "cidr": "10.55.32.0/20",
-                            "rdns_mode": 2,
-                            "gateway_ip": "10.55.32.1",
-                            "dns_servers": [],
-                            "allow_dns": true,
-                            "allow_proxy": true,
-                            "active_discovery": false,
-                            "managed": true,
-                            "id": 1,
-                            "space": "undefined",
-                            "resource_uri": "/MAAS/api/2.0/subnets/1/"
-                        }
-                    }
-                ],
-                "resource_uri": "/MAAS/api/2.0/nodes/6gsym8/interfaces/1/"
-            },
-            {
-                "vlan": {
-                    "vid": 0,
-                    "mtu": 1500,
-                    "dhcp_on": false,
-                    "external_dhcp": null,
-                    "relay_vlan": null,
-                    "id": 5002,
-                    "name": "untagged",
-                    "fabric_id": 1,
-                    "secondary_rack": null,
-                    "space": "undefined",
-                    "fabric": "fabric-1",
-                    "primary_rack": null,
-                    "resource_uri": "/MAAS/api/2.0/vlans/5002/"
-                },
-                "mac_address": "52:54:00:09:88:41",
-                "tags": [],
-                "params": "",
-                "id": 17,
-                "discovered": [],
-                "product": null,
-                "parents": [],
-                "type": "bridge",
-                "name": "virbr0",
-                "enabled": true,
-                "effective_mtu": 1500,
-                "vendor": null,
-                "system_id": "6gsym8",
-                "children": [],
-                "firmware_version": null,
-                "links": [
-                    {
-                        "id": 17,
-                        "mode": "static",
-                        "ip_address": "192.168.122.1",
-                        "subnet": {
-                            "name": "192.168.122.0/24",
+                            "name": "10.10.0.0/24",
+                            "description": "",
                             "vlan": {
                                 "vid": 0,
                                 "mtu": 1500,
                                 "dhcp_on": false,
                                 "external_dhcp": null,
                                 "relay_vlan": null,
-                                "id": 5002,
-                                "name": "untagged",
-                                "fabric_id": 1,
+                                "primary_rack": null,
+                                "id": 1,
+                                "space": "undefined",
+                                "fabric": "fabric-0",
+                                "fabric_id": 0,
                                 "secondary_rack": null,
+                                "name": "untagged",
+                                "resource_uri": "/MAAS/api/2.0/vlans/1/"
+                            },
+                            "cidr": "10.10.0.0/24",
+                            "rdns_mode": 2,
+                            "gateway_ip": "10.10.0.1",
+                            "dns_servers": [],
+                            "allow_dns": true,
+                            "allow_proxy": true,
+                            "active_discovery": false,
+                            "managed": true,
+                            "disabled_boot_architectures": [],
+                            "id": 1,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/subnets/1/"
+                        }
+                    }
+                ],
+                "link_connected": true,
+                "vlan": {
+                    "vid": 0,
+                    "mtu": 1500,
+                    "dhcp_on": false,
+                    "external_dhcp": null,
+                    "relay_vlan": null,
+                    "primary_rack": null,
+                    "id": 1,
+                    "space": "undefined",
+                    "fabric": "fabric-0",
+                    "fabric_id": 0,
+                    "secondary_rack": null,
+                    "name": "untagged",
+                    "resource_uri": "/MAAS/api/2.0/vlans/1/"
+                },
+                "interface_speed": 0,
+                "params": {},
+                "parents": [],
+                "tags": [],
+                "vendor": null,
+                "id": 1,
+                "name": "eth0",
+                "discovered": null,
+                "link_speed": 0,
+                "sriov_max_vf": 0,
+                "firmware_version": null,
+                "type": "physical",
+                "resource_uri": "/MAAS/api/2.0/nodes/m6w3b4/interfaces/1/"
+            },
+            {
+                "system_id": "m6w3b4",
+                "enabled": true,
+                "children": [],
+                "numa_node": 0,
+                "mac_address": "00:16:3e:6d:ff:2f",
+                "product": null,
+                "effective_mtu": 1500,
+                "links": [
+                    {
+                        "id": 2,
+                        "mode": "static",
+                        "ip_address": "10.20.0.2",
+                        "subnet": {
+                            "name": "10.20.0.0/24",
+                            "description": "",
+                            "vlan": {
+                                "vid": 0,
+                                "mtu": 1500,
+                                "dhcp_on": true,
+                                "external_dhcp": null,
+                                "relay_vlan": null,
+                                "primary_rack": "m6w3b4",
+                                "id": 2,
                                 "space": "undefined",
                                 "fabric": "fabric-1",
-                                "primary_rack": null,
-                                "resource_uri": "/MAAS/api/2.0/vlans/5002/"
+                                "fabric_id": 1,
+                                "secondary_rack": null,
+                                "name": "untagged",
+                                "resource_uri": "/MAAS/api/2.0/vlans/2/"
                             },
-                            "cidr": "192.168.122.0/24",
+                            "cidr": "10.20.0.0/24",
+                            "rdns_mode": 2,
+                            "gateway_ip": "10.20.0.1",
+                            "dns_servers": [],
+                            "allow_dns": true,
+                            "allow_proxy": true,
+                            "active_discovery": false,
+                            "managed": true,
+                            "disabled_boot_architectures": [],
+                            "id": 2,
+                            "space": "undefined",
+                            "resource_uri": "/MAAS/api/2.0/subnets/2/"
+                        }
+                    }
+                ],
+                "link_connected": true,
+                "vlan": {
+                    "vid": 0,
+                    "mtu": 1500,
+                    "dhcp_on": true,
+                    "external_dhcp": null,
+                    "relay_vlan": null,
+                    "primary_rack": "m6w3b4",
+                    "id": 2,
+                    "space": "undefined",
+                    "fabric": "fabric-1",
+                    "fabric_id": 1,
+                    "secondary_rack": null,
+                    "name": "untagged",
+                    "resource_uri": "/MAAS/api/2.0/vlans/2/"
+                },
+                "interface_speed": 0,
+                "params": {},
+                "parents": [],
+                "tags": [],
+                "vendor": null,
+                "id": 2,
+                "name": "eth1",
+                "discovered": null,
+                "link_speed": 0,
+                "sriov_max_vf": 0,
+                "firmware_version": null,
+                "type": "physical",
+                "resource_uri": "/MAAS/api/2.0/nodes/m6w3b4/interfaces/2/"
+            },
+            {
+                "system_id": "m6w3b4",
+                "enabled": true,
+                "children": [],
+                "numa_node": null,
+                "mac_address": "52:54:00:59:9b:a9",
+                "product": null,
+                "effective_mtu": 1500,
+                "links": [
+                    {
+                        "id": 191,
+                        "mode": "static",
+                        "ip_address": "10.38.222.1",
+                        "subnet": {
+                            "name": "10.38.222.0/24",
+                            "description": "",
+                            "vlan": {
+                                "vid": 0,
+                                "mtu": 1500,
+                                "dhcp_on": false,
+                                "external_dhcp": null,
+                                "relay_vlan": null,
+                                "primary_rack": null,
+                                "id": 19,
+                                "space": "undefined",
+                                "fabric": "fabric-7",
+                                "fabric_id": 7,
+                                "secondary_rack": null,
+                                "name": "untagged",
+                                "resource_uri": "/MAAS/api/2.0/vlans/19/"
+                            },
+                            "cidr": "10.38.222.0/24",
                             "rdns_mode": 2,
                             "gateway_ip": null,
                             "dns_servers": [],
@@ -239,44 +361,47 @@
                             "allow_proxy": true,
                             "active_discovery": false,
                             "managed": true,
-                            "id": 2,
+                            "disabled_boot_architectures": [],
+                            "id": 12,
                             "space": "undefined",
-                            "resource_uri": "/MAAS/api/2.0/subnets/2/"
+                            "resource_uri": "/MAAS/api/2.0/subnets/12/"
                         }
                     }
                 ],
-                "resource_uri": "/MAAS/api/2.0/nodes/6gsym8/interfaces/17/"
+                "link_connected": true,
+                "vlan": {
+                    "vid": 0,
+                    "mtu": 1500,
+                    "dhcp_on": false,
+                    "external_dhcp": null,
+                    "relay_vlan": null,
+                    "primary_rack": null,
+                    "id": 19,
+                    "space": "undefined",
+                    "fabric": "fabric-7",
+                    "fabric_id": 7,
+                    "secondary_rack": null,
+                    "name": "untagged",
+                    "resource_uri": "/MAAS/api/2.0/vlans/19/"
+                },
+                "interface_speed": 0,
+                "params": {},
+                "parents": [],
+                "tags": [],
+                "vendor": null,
+                "id": 154,
+                "name": "mpqemubr0",
+                "discovered": null,
+                "link_speed": 0,
+                "sriov_max_vf": 0,
+                "firmware_version": null,
+                "type": "bridge",
+                "resource_uri": "/MAAS/api/2.0/nodes/m6w3b4/interfaces/154/"
             }
         ],
-        "cpu_speed": 2400,
-        "testing_status_name": "Unknown",
-        "tag_names": [
-            "virtual"
-        ],
-        "current_commissioning_result_id": 1,
-        "system_id": "6gsym8",
-        "distro_series": "bionic",
-        "cpu_test_status": -1,
-        "memory_test_status_name": "Unknown",
-        "hardware_info": {
-            "system_vendor": "OpenStack Foundation",
-            "system_product": "OpenStack Nova",
-            "system_version": "2013.2.3",
-            "system_serial": "33313934-3432-5a43-4339-343532355a35",
-            "cpu_model": "Intel Core i7 9xx (Nehalem Class Core i7)",
-            "mainboard_vendor": "Unknown",
-            "mainboard_product": "Unknown",
-            "mainboard_firmware_version": "Bochs",
-            "mainboard_firmware_date": "01/01/2011"
-        },
-        "other_test_status_name": "Unknown",
-        "fqdn": "mymaas.maas",
-        "power_state": "unknown",
-        "memory_test_status": -1,
+        "cpu_speed": 5000,
+        "testing_status": -1,
         "current_installation_result_id": null,
-        "storage_test_status_name": "Unknown",
-        "architecture": "amd64/generic",
-        "cpu_test_status_name": "Unknown",
-        "resource_uri": "/MAAS/api/2.0/rackcontrollers/6gsym8/"
+        "resource_uri": "/MAAS/api/2.0/rackcontrollers/m6w3b4/"
     }
 ]


### PR DESCRIPTION
This PR includes the following changes:

- Update Rack controller entities which were incomplete and not used
- Add interactions with Rack controller(s) endpoints
- Move node logic from machine to node and let machines and rack controllers inherit them
- Update rack controller sample JSON responses, used for tests
- Update of `Subnet` entity to include missing fields. This is needed to have successful rack controller tests. The tests are failing if the Go structs do not contain fields found in the response. Subnet is indirect as `Rack Controller` -> `Interfaces` -> `Links` -> `Subnets`
- Add some missing fields to machines
- Fix a typo in one of rack controller test names